### PR TITLE
Initialize DiffVoyager project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+*.lcov
+
+# Build outputs
+dist/
+build/
+*.tsbuildinfo
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Editor
+.vscode/*
+!.vscode/extensions.json
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# DiffVoyager specific
+data/
+storage/
+artifacts/
+screenshots/
+har-files/
+diff-images/
+
+# Frontend
+packages/frontend/dist-ssr
+packages/frontend/.vite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,226 @@
+# DiffVoyager - Claude Code Development Guide
+
+## Project Overview
+
+DiffVoyager is a local website version comparison tool designed for solo developers upgrading frameworks and dependencies. It verifies that code changes maintain visual correctness, content integrity, SEO compliance, and performance metrics.
+
+## Architecture
+
+### Monorepo Structure
+
+```
+diff-voyager/
+├── packages/
+│   ├── backend/          # Node.js + TypeScript crawler & API
+│   ├── frontend/         # Vue 3 + TypeScript UI (built with bun)
+│   └── shared/           # Shared TypeScript types
+├── docs/                 # Documentation
+├── .claude/              # Claude Code configuration
+│   └── PRD.md           # Product Requirements Document
+└── README.md
+```
+
+### Technology Stack
+
+**Backend:**
+- Node.js v22 with TypeScript
+- Crawlee + Playwright for browser automation and crawling
+- Persistent queue and storage (SQLite planned)
+- Local HTTP API for frontend communication
+
+**Frontend:**
+- Vue.js 3 + TypeScript
+- Built with bun
+- Communicates with backend via local API
+
+**Shared:**
+- TypeScript types shared between backend and frontend
+- Domain models: Project, Run, Page, PageSnapshot, Diff, Rule/Mute
+
+## Core Domain Models
+
+### Project
+- Configuration for crawling (base URL, scope rules)
+- Run profiles (which artifacts to collect)
+- Ignore filters (CSS/XPath, headers)
+- Collection of Runs
+
+### Baseline
+- First full run of a project
+- Reference set of pages and artifacts
+- Immutable within project
+
+### Run
+- Comparison run against baseline
+- Status tracking (new, in_progress, interrupted, completed)
+- Statistics and diff results
+
+### Page
+- Normalized page identifier
+- URL normalization rules
+- Related entries in baseline and runs
+
+### PageSnapshot
+- Raw HTML/DOM with hash
+- HTTP headers and status
+- SEO data (title, meta, canonical, robots, H1)
+- Artifacts: screenshots, HAR files, diffs
+- Performance metadata
+
+### Diff
+- HTML/SEO comparison results
+- Visual comparison (pixel diff)
+- HAR/performance comparison
+- Business status: new, accepted, muted
+
+### Rule/MuteRule
+- Ignore/mute rules (CSS/XPath selectors)
+- Scope (global/per project)
+- Associated difference types
+
+## Development Workflow
+
+### TDD Approach
+
+Development follows Test-Driven Development:
+
+1. **Unit Tests:**
+   - Domain models and business logic
+   - Comparison logic (HTML/SEO, visual, performance)
+   - Mute rules and acceptance logic
+
+2. **Integration Tests:**
+   - Test server with controlled HTML/CSS
+   - Crawler traversal and result saving
+   - Comparison runs on modified versions
+
+3. **E2E Tests:**
+   - Full flow: create project → baseline → run → review
+
+### Main Solo Developer Flow
+
+1. Create new project with base URL
+2. Run full crawl to establish baseline
+3. Make code changes (outside tool)
+4. Run comparison against baseline
+5. Review differences (SEO, visual, performance)
+6. Fix issues and rerun until acceptable
+7. Accept or mute remaining differences
+
+## Key Features
+
+### Data Collection (Per Page)
+- HTML and HTTP headers
+- HTTP status and redirects
+- SEO metadata extraction
+- Full-page screenshots (configurable viewport)
+- HAR files with performance metrics (optional)
+
+### Comparison & Diff
+- **HTML/SEO:** Changes in meta tags, content
+- **Visual:** Pixel-by-pixel diff with threshold
+- **Performance:** Load time, request count, total size changes
+
+### Diff Management
+- Mark differences as "accepted"
+- Create mute rules from specific differences
+- Filter by difference type
+- Show/hide muted differences
+
+### Export
+- JSON manifest with project data
+- Directory structure with all artifacts
+- HTML, screenshots, diffs, HAR files
+
+## Development Commands
+
+### Initial Setup
+```bash
+npm install              # Install root dependencies
+npm run setup            # Setup all packages
+```
+
+### Backend Development
+```bash
+cd packages/backend
+npm install
+npm run dev              # Start in development mode
+npm test                 # Run tests
+npm run test:watch       # Watch mode
+```
+
+### Frontend Development
+```bash
+cd packages/frontend
+bun install
+bun run dev              # Start dev server
+bun test                 # Run tests
+```
+
+### Shared Types
+```bash
+cd packages/shared
+npm install
+npm run build            # Build types
+npm test                 # Validate types
+```
+
+## Testing Strategy
+
+### Backend Tests
+- Domain model tests
+- Crawler integration tests
+- API endpoint tests
+- Comparison logic tests
+
+### Frontend Tests
+- Component tests
+- View integration tests
+- Type validation tests
+
+## Non-Functional Requirements
+
+- **Local operation:** No permanent internet required
+- **Performance:** Handle hundreds of pages reasonably
+- **Stability:** Resume after interruption
+- **Security:** Anonymize sensitive fields via rules
+
+## Risks & Mitigations
+
+- **Dynamic content:** Use CSS/XPath filters and mute rules
+- **Large websites:** Page/time limits, restricted artifact profiles
+- **Simple visual diff:** Pixel-by-pixel may have false positives
+- **No advanced auth:** MVP doesn't support complex login
+
+## Success Criteria
+
+- Complete framework migration without losing SEO elements
+- Identify critical regressions in 1-2 comparison runs
+- Transparent report for focused review session
+- Stable operation on typical project sizes
+
+## Future Enhancements (Out of MVP Scope)
+
+- CI/CD integration
+- SEO tool integration
+- Email/Slack notifications
+- Advanced visual diff algorithms
+- Multi-user support
+- Docker deployment
+
+## Contributing
+
+When working on DiffVoyager:
+
+1. Read the PRD in `.claude/PRD.md`
+2. Follow TDD - write tests first
+3. Use shared TypeScript types
+4. Keep changes focused and simple
+5. Update documentation as needed
+
+## Git Workflow
+
+- Main branch: (check git status)
+- Feature branches: Use descriptive names
+- Commit messages: Clear, concise descriptions
+- Push regularly to backup work

--- a/README.md
+++ b/README.md
@@ -1,0 +1,199 @@
+# DiffVoyager
+
+> **Local Website Version Comparison Tool for Framework Migrations**
+
+DiffVoyager helps solo developers verify that framework upgrades and dependency changes don't break their websites. It crawls your site, captures baselines, and compares visual appearance, SEO metadata, and performance metrics across versions.
+
+## Features
+
+- **Visual Regression Detection**: Pixel-perfect screenshot comparison with configurable thresholds
+- **SEO Integrity Checks**: Verify title tags, meta descriptions, canonical URLs, robots directives, and heading structure
+- **Performance Monitoring**: Track load times, request counts, and total page size via HAR files
+- **Smart Diff Management**: Accept changes or create mute rules to filter out expected differences
+- **Resumable Crawls**: Interrupt and resume runs without losing progress
+- **Project-Based Workflow**: Manage multiple migration projects with separate baselines
+
+## Architecture
+
+DiffVoyager is a monorepo with three packages:
+
+```
+packages/
+├── backend/   # Node.js crawler and API (Crawlee + Playwright)
+├── frontend/  # Vue 3 UI (built with bun)
+└── shared/    # Shared TypeScript types
+```
+
+## Requirements
+
+- **Node.js**: v22 or higher
+- **Bun**: Latest version (for frontend development)
+- **Operating System**: Linux, macOS, or Windows with WSL2
+
+## Quick Start
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/gander-tools/diff-voyager.git
+cd diff-voyager
+
+# Install dependencies
+npm install
+npm run setup
+```
+
+### Usage
+
+```bash
+# Start backend API
+npm run dev:backend
+
+# In another terminal, start frontend
+npm run dev:frontend
+```
+
+Visit `http://localhost:5173` to access the UI.
+
+## Development
+
+### Project Structure
+
+```
+diff-voyager/
+├── packages/
+│   ├── backend/          # Crawler, API, diff engine
+│   │   ├── src/
+│   │   │   ├── crawler/  # Crawlee + Playwright integration
+│   │   │   ├── api/      # Fastify HTTP API
+│   │   │   ├── domain/   # Business logic
+│   │   │   └── storage/  # Persistence layer
+│   │   └── tests/
+│   ├── frontend/         # Vue 3 application
+│   │   ├── src/
+│   │   │   ├── views/    # Page components
+│   │   │   ├── components/
+│   │   │   ├── stores/   # Pinia state management
+│   │   │   └── router/
+│   │   └── tests/
+│   └── shared/           # Domain models and types
+│       ├── src/
+│       │   ├── types/    # TypeScript interfaces
+│       │   └── models/   # Domain entities
+│       └── tests/
+├── docs/                 # Documentation
+├── .claude/              # Claude Code configuration
+│   └── PRD.md           # Product Requirements Document
+└── README.md
+```
+
+### Testing
+
+DiffVoyager follows Test-Driven Development (TDD):
+
+```bash
+# Run all tests
+npm test
+
+# Test specific package
+npm run test:backend
+npm run test:frontend
+npm run test:shared
+
+# Watch mode
+cd packages/backend && npm run test:watch
+```
+
+### Building
+
+```bash
+# Build all packages
+npm run build
+
+# Build specific package
+npm run build:backend
+npm run build:frontend
+npm run build:shared
+```
+
+## Typical Workflow
+
+1. **Create Project**: Set up a new project with your website's base URL
+2. **Establish Baseline**: Run a full crawl to capture the current state
+3. **Make Changes**: Update your framework, dependencies, or code
+4. **Run Comparison**: Crawl the updated site and compare against baseline
+5. **Review Diffs**: Examine visual, SEO, and performance differences
+6. **Accept or Mute**: Mark acceptable changes or create rules to ignore expected differences
+7. **Iterate**: Fix issues and rerun until all critical differences are resolved
+
+## Core Concepts
+
+### Project
+A migration effort with configuration for crawling, comparison profiles, and mute rules.
+
+### Baseline
+The reference snapshot of your site before changes. Immutable within a project.
+
+### Run
+A comparison crawl against the baseline. Track status, statistics, and differences.
+
+### Page Snapshot
+Complete capture of a page: HTML, HTTP headers, SEO data, screenshot, HAR file, and performance metrics.
+
+### Diff
+Comparison results between baseline and run for a specific page. Includes HTML/SEO changes, visual differences, and performance deltas.
+
+### Mute Rules
+Filters to ignore expected differences (e.g., timestamps, analytics scripts, dynamic content).
+
+## Technology Stack
+
+- **Backend**: Node.js 22, TypeScript, Crawlee, Playwright, Fastify
+- **Frontend**: Vue 3, TypeScript, Pinia, Vite, built with bun
+- **Testing**: Vitest
+- **Diff Engine**: Pixelmatch for visual comparison
+
+## Documentation
+
+- [Product Requirements Document](.claude/PRD.md) - Detailed feature specifications
+- [Claude Code Guide](CLAUDE.md) - Development guide for AI-assisted coding
+
+## Contributing
+
+1. Read the [PRD](.claude/PRD.md) to understand requirements
+2. Follow TDD - write tests first
+3. Use shared TypeScript types from `@diff-voyager/shared`
+4. Keep changes focused and avoid over-engineering
+5. Update documentation as needed
+
+## License
+
+MIT
+
+## Roadmap
+
+### MVP (In Progress)
+- [x] Project initialization and structure
+- [ ] Domain model implementation
+- [ ] Crawler with Crawlee + Playwright
+- [ ] Screenshot and visual diff engine
+- [ ] SEO metadata extraction
+- [ ] HAR file capture and performance metrics
+- [ ] Local API with Fastify
+- [ ] Vue 3 UI with project and run management
+- [ ] Diff review and acceptance workflow
+- [ ] Mute rules and filters
+- [ ] Export functionality
+
+### Future Enhancements
+- CI/CD integration (GitHub Actions, GitLab CI)
+- SEO tool integration
+- Advanced visual diff algorithms
+- Multi-user support
+- Docker deployment
+- Email/Slack notifications
+
+## Support
+
+For issues, questions, or contributions, please visit the [GitHub repository](https://github.com/gander-tools/diff-voyager).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "diff-voyager",
+  "version": "0.1.0",
+  "description": "Local website version comparison tool for framework migrations - crawl, compare, and verify visual, SEO, and performance changes",
+  "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "setup": "npm install && npm run build:shared",
+    "build:shared": "npm run build --workspace=@diff-voyager/shared",
+    "build:backend": "npm run build --workspace=@diff-voyager/backend",
+    "build:frontend": "npm run build --workspace=@diff-voyager/frontend",
+    "build": "npm run build:shared && npm run build:backend && npm run build:frontend",
+    "dev:backend": "npm run dev --workspace=@diff-voyager/backend",
+    "dev:frontend": "npm run dev --workspace=@diff-voyager/frontend",
+    "test": "npm run test --workspaces --if-present",
+    "test:backend": "npm run test --workspace=@diff-voyager/backend",
+    "test:frontend": "npm run test --workspace=@diff-voyager/frontend",
+    "test:shared": "npm run test --workspace=@diff-voyager/shared",
+    "lint": "npm run lint --workspaces --if-present",
+    "clean": "npm run clean --workspaces --if-present && rm -rf node_modules"
+  },
+  "keywords": [
+    "diff",
+    "visual-regression",
+    "seo",
+    "performance",
+    "crawler",
+    "website-comparison",
+    "framework-migration",
+    "testing"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gander-tools/diff-voyager.git"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@diff-voyager/backend",
+  "version": "0.1.0",
+  "description": "Backend crawler and API for DiffVoyager",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts"
+  },
+  "keywords": [
+    "diff-voyager",
+    "backend",
+    "crawler",
+    "api"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@diff-voyager/shared": "workspace:*",
+    "crawlee": "^3.12.3",
+    "playwright": "^1.49.1",
+    "fastify": "^5.2.0",
+    "pixelmatch": "^6.0.0",
+    "pngjs": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@types/pixelmatch": "^5.2.6",
+    "@types/pngjs": "^6.0.5",
+    "eslint": "^9.17.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * DiffVoyager Backend
+ *
+ * Main entry point for the backend API and crawler service.
+ */
+
+console.log('DiffVoyager Backend - Starting...');
+
+// Placeholder - will be implemented in TDD fashion
+async function main() {
+  console.log('Backend initialized');
+  console.log('API server will be started here');
+  console.log('Crawler service will be initialized here');
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DiffVoyager</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@diff-voyager/frontend",
+  "version": "0.1.0",
+  "description": "Vue.js frontend for DiffVoyager",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+  },
+  "keywords": [
+    "diff-voyager",
+    "frontend",
+    "vue"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@diff-voyager/shared": "workspace:*",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0",
+    "pinia": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/eslint-config-typescript": "^14.1.3",
+    "@vue/test-utils": "^2.4.6",
+    "eslint": "^9.17.0",
+    "eslint-plugin-vue": "^9.31.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.5",
+    "vitest": "^2.1.8",
+    "vue-tsc": "^2.1.10"
+  }
+}

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -1,0 +1,21 @@
+/**
+ * DiffVoyager Frontend
+ *
+ * Main entry point for the Vue 3 application.
+ */
+
+import { createApp } from 'vue';
+// import { createPinia } from 'pinia';
+// import App from './App.vue';
+// import router from './router';
+
+console.log('DiffVoyager Frontend - Starting...');
+
+// Placeholder - will be implemented later
+// const app = createApp(App);
+// app.use(createPinia());
+// app.use(router);
+// app.mount('#app');
+
+console.log('Frontend will be initialized here');
+console.log('Vue 3 app with Pinia and Router will be set up');

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["node_modules"]
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath, URL } from 'node:url';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  server: {
+    port: 5173,
+  },
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@diff-voyager/shared",
+  "version": "0.1.0",
+  "description": "Shared TypeScript types and utilities for DiffVoyager",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts"
+  },
+  "keywords": [
+    "diff-voyager",
+    "types",
+    "shared"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "eslint": "^9.17.0",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Status of a run
+ */
+export enum RunStatus {
+  NEW = 'new',
+  IN_PROGRESS = 'in_progress',
+  INTERRUPTED = 'interrupted',
+  COMPLETED = 'completed',
+}
+
+/**
+ * Status of a page within a run
+ */
+export enum PageStatus {
+  PENDING = 'pending',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  PARTIAL = 'partial',
+  ERROR = 'error',
+}
+
+/**
+ * Types of differences that can be detected
+ */
+export enum DiffType {
+  SEO = 'seo',
+  VISUAL = 'visual',
+  CONTENT = 'content',
+  PERFORMANCE = 'performance',
+  HTTP_STATUS = 'http_status',
+  HEADERS = 'headers',
+}
+
+/**
+ * Business status of a detected difference
+ */
+export enum DiffStatus {
+  NEW = 'new',
+  ACCEPTED = 'accepted',
+  MUTED = 'muted',
+}
+
+/**
+ * Severity level of a difference
+ */
+export enum DiffSeverity {
+  CRITICAL = 'critical',
+  WARNING = 'warning',
+  INFO = 'info',
+}
+
+/**
+ * Scope of a mute rule
+ */
+export enum RuleScope {
+  GLOBAL = 'global',
+  PROJECT = 'project',
+}
+
+/**
+ * Run profile types (which artifacts to collect)
+ */
+export enum RunProfile {
+  VISUAL_SEO = 'visual_seo',
+  FULL = 'full',
+  MINIMAL = 'minimal',
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * DiffVoyager Shared Types and Enums
+ *
+ * This package contains shared TypeScript types and enums used across
+ * the backend and frontend packages of DiffVoyager.
+ */
+
+// Export all enums
+export * from './enums/index.js';
+
+// Export all types
+export * from './types/index.js';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,318 @@
+import {
+  RunStatus,
+  PageStatus,
+  DiffType,
+  DiffStatus,
+  DiffSeverity,
+  RuleScope,
+  RunProfile,
+} from '../enums/index.js';
+
+/**
+ * Project - represents a migration effort with baseline and comparison runs
+ */
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  baseUrl: string;
+  createdAt: Date;
+  updatedAt: Date;
+  config: ProjectConfig;
+}
+
+/**
+ * Project configuration
+ */
+export interface ProjectConfig {
+  crawl: CrawlConfig;
+  runProfile: RunProfile;
+  ignoreFilters: IgnoreFilters;
+  viewport: ViewportConfig;
+  thresholds: ThresholdConfig;
+}
+
+/**
+ * Crawl configuration
+ */
+export interface CrawlConfig {
+  baseUrl: string;
+  scopeRules: ScopeRules;
+  maxPages?: number;
+  maxDurationMs?: number;
+  maxConcurrency?: number;
+  maxRetries?: number;
+}
+
+/**
+ * Scope rules for crawling
+ */
+export interface ScopeRules {
+  includeDomains: string[];
+  includeSubdomains: boolean;
+  excludePatterns: string[];
+  includePatterns?: string[];
+}
+
+/**
+ * Ignore filters for comparison
+ */
+export interface IgnoreFilters {
+  cssSelectors: string[];
+  xpathSelectors: string[];
+  httpHeaders: string[];
+  anonymizeFields: string[];
+}
+
+/**
+ * Viewport configuration for screenshots
+ */
+export interface ViewportConfig {
+  width: number;
+  height: number;
+  deviceScaleFactor?: number;
+}
+
+/**
+ * Threshold configuration for diff detection
+ */
+export interface ThresholdConfig {
+  visualDiffPercentage: number;
+  performanceLoadTimeIncreaseMs?: number;
+  performanceRequestCountIncrease?: number;
+  performanceSizeIncreaseBytes?: number;
+}
+
+/**
+ * Baseline - immutable reference snapshot of a project
+ */
+export interface Baseline {
+  id: string;
+  projectId: string;
+  createdAt: Date;
+  runId: string; // Reference to the run that created the baseline
+  pageCount: number;
+  config: ProjectConfig; // Snapshot of config at baseline creation
+}
+
+/**
+ * Run - a comparison crawl against the baseline
+ */
+export interface Run {
+  id: string;
+  projectId: string;
+  baselineId: string;
+  status: RunStatus;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  interruptedAt?: Date;
+  config: RunConfig;
+  statistics: RunStatistics;
+}
+
+/**
+ * Run configuration
+ */
+export interface RunConfig {
+  profile: RunProfile;
+  viewport: ViewportConfig;
+  captureHar: boolean;
+  captureScreenshots: boolean;
+  generateDiffImages: boolean;
+}
+
+/**
+ * Run statistics
+ */
+export interface RunStatistics {
+  totalPages: number;
+  completedPages: number;
+  errorPages: number;
+  unchangedPages: number;
+  changedPages: number;
+  criticalDifferences: number;
+  acceptedDifferences: number;
+  mutedDifferences: number;
+}
+
+/**
+ * Page - normalized page identifier within a project
+ */
+export interface Page {
+  id: string;
+  projectId: string;
+  normalizedUrl: string;
+  originalUrl: string;
+  createdAt: Date;
+}
+
+/**
+ * Page snapshot - complete capture of a page at a specific point in time
+ */
+export interface PageSnapshot {
+  id: string;
+  pageId: string;
+  runId: string;
+  status: PageStatus;
+  capturedAt: Date;
+  httpStatus: number;
+  redirectChain?: Redirect[];
+  html: string;
+  htmlHash: string;
+  httpHeaders: Record<string, string>;
+  seoData: SeoData;
+  performance?: PerformanceData;
+  artifacts: ArtifactReferences;
+  error?: string;
+}
+
+/**
+ * HTTP redirect information
+ */
+export interface Redirect {
+  from: string;
+  to: string;
+  status: number;
+}
+
+/**
+ * SEO metadata extracted from a page
+ */
+export interface SeoData {
+  title?: string;
+  metaDescription?: string;
+  canonical?: string;
+  robots?: string;
+  h1?: string[];
+  h2?: string[];
+  openGraph?: Record<string, string>;
+  twitterCard?: Record<string, string>;
+  lang?: string;
+}
+
+/**
+ * Performance data and metrics
+ */
+export interface PerformanceData {
+  loadTimeMs: number;
+  requestCount: number;
+  totalSizeBytes: number;
+  resourceTimings?: ResourceTiming[];
+}
+
+/**
+ * Resource timing information
+ */
+export interface ResourceTiming {
+  url: string;
+  type: string;
+  durationMs: number;
+  sizeBytes: number;
+}
+
+/**
+ * References to stored artifacts
+ */
+export interface ArtifactReferences {
+  screenshotPath?: string;
+  harPath?: string;
+  diffImagePath?: string;
+}
+
+/**
+ * Diff - comparison result between baseline and run for a page
+ */
+export interface Diff {
+  id: string;
+  pageId: string;
+  runId: string;
+  baselineSnapshotId: string;
+  runSnapshotId: string;
+  createdAt: Date;
+  changes: Change[];
+  summary: DiffSummary;
+}
+
+/**
+ * Individual change detected in a diff
+ */
+export interface Change {
+  id: string;
+  type: DiffType;
+  severity: DiffSeverity;
+  status: DiffStatus;
+  description: string;
+  details: ChangeDetails;
+  mutedByRuleId?: string;
+  acceptedAt?: Date;
+  acceptedBy?: string;
+}
+
+/**
+ * Details of a specific change
+ */
+export interface ChangeDetails {
+  field?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  selector?: string;
+  xpath?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Summary of all changes in a diff
+ */
+export interface DiffSummary {
+  totalChanges: number;
+  criticalChanges: number;
+  acceptedChanges: number;
+  mutedChanges: number;
+  changesByType: Record<DiffType, number>;
+  visualDiffPercentage?: number;
+  visualDiffPixels?: number;
+  thresholdExceeded: boolean;
+}
+
+/**
+ * Mute rule - defines which differences to ignore
+ */
+export interface MuteRule {
+  id: string;
+  projectId?: string;
+  name: string;
+  description?: string;
+  scope: RuleScope;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  conditions: RuleCondition[];
+}
+
+/**
+ * Condition for a mute rule
+ */
+export interface RuleCondition {
+  diffType: DiffType;
+  cssSelector?: string;
+  xpathSelector?: string;
+  fieldPattern?: string;
+  headerName?: string;
+  valuePattern?: string;
+}
+
+/**
+ * Export manifest for project data
+ */
+export interface ExportManifest {
+  version: string;
+  exportedAt: Date;
+  project: Project;
+  baseline: Baseline;
+  runs: Run[];
+  pages: Page[];
+  snapshots: PageSnapshot[];
+  diffs: Diff[];
+  muteRules: MuteRule[];
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "lib": ["ES2022"],
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "incremental": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
- Add monorepo structure with three packages: backend, frontend, shared
- Configure Node.js v22 with TypeScript and npm workspaces
- Define shared TypeScript types for domain models (Project, Run, Page, Diff, etc.)
- Set up backend package with Crawlee, Playwright, and Fastify
- Set up frontend package with Vue 3, Pinia, and Vite (built with bun)
- Add comprehensive documentation (CLAUDE.md, README.md)
- Configure TypeScript for all packages with strict mode
- Add .gitignore for build outputs and artifacts

This establishes the foundation for the local website version comparison tool per the PRD specifications.