### PR TITLE
Configure monorepo packages with @gander-tools scope

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  ".": "0.0.0"
+  "packages/shared": "0.0.0",
+  "packages/backend": "0.0.0",
+  "packages/frontend": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diff-voyager",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Local website version comparison tool for framework migrations - crawl, compare, and verify visual, SEO, and performance changes",
   "private": true,
   "engines": {
@@ -11,16 +11,16 @@
   ],
   "scripts": {
     "setup": "npm install && npm run build:shared",
-    "build:shared": "npm run build --workspace=@diff-voyager/shared",
-    "build:backend": "npm run build --workspace=@diff-voyager/backend",
-    "build:frontend": "npm run build --workspace=@diff-voyager/frontend",
+    "build:shared": "npm run build --workspace=@gander-tools/diff-voyager-shared",
+    "build:backend": "npm run build --workspace=@gander-tools/diff-voyager-backend",
+    "build:frontend": "npm run build --workspace=@gander-tools/diff-voyager-frontend",
     "build": "npm run build:shared && npm run build:backend && npm run build:frontend",
-    "dev:backend": "npm run dev --workspace=@diff-voyager/backend",
-    "dev:frontend": "npm run dev --workspace=@diff-voyager/frontend",
+    "dev:backend": "npm run dev --workspace=@gander-tools/diff-voyager-backend",
+    "dev:frontend": "npm run dev --workspace=@gander-tools/diff-voyager-frontend",
     "test": "npm run test --workspaces --if-present",
-    "test:backend": "npm run test --workspace=@diff-voyager/backend",
-    "test:frontend": "npm run test --workspace=@diff-voyager/frontend",
-    "test:shared": "npm run test --workspace=@diff-voyager/shared",
+    "test:backend": "npm run test --workspace=@gander-tools/diff-voyager-backend",
+    "test:frontend": "npm run test --workspace=@gander-tools/diff-voyager-frontend",
+    "test:shared": "npm run test --workspace=@gander-tools/diff-voyager-shared",
     "lint": "npm run lint --workspaces --if-present",
     "clean": "npm run clean --workspaces --if-present && rm -rf node_modules"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "diff-voyager",
-  "version": "0.0.0",
   "description": "Local website version comparison tool for framework migrations - crawl, compare, and verify visual, SEO, and performance changes",
   "private": true,
   "engines": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@diff-voyager/backend",
-  "version": "0.1.0",
+  "name": "@gander-tools/diff-voyager-backend",
+  "version": "0.0.0",
   "description": "Backend crawler and API for DiffVoyager",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@diff-voyager/shared": "workspace:*",
+    "@gander-tools/diff-voyager-shared": "workspace:*",
     "crawlee": "^3.12.3",
     "playwright": "^1.49.1",
     "fastify": "^5.2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@diff-voyager/frontend",
-  "version": "0.1.0",
+  "name": "@gander-tools/diff-voyager-frontend",
+  "version": "0.0.0",
   "description": "Vue.js frontend for DiffVoyager",
   "type": "module",
   "scripts": {
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@diff-voyager/shared": "workspace:*",
+    "@gander-tools/diff-voyager-shared": "workspace:*",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
     "pinia": "^2.3.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@diff-voyager/shared",
-  "version": "0.1.0",
+  "name": "@gander-tools/diff-voyager-shared",
+  "version": "0.0.0",
   "description": "Shared TypeScript types and utilities for DiffVoyager",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,25 @@
 {
   "packages": {
-    ".": {
-      "package-name": "@gander-tools/diff-voyager",
+    "packages/shared": {
+      "package-name": "@gander-tools/diff-voyager-shared",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    },
+    "packages/backend": {
+      "package-name": "@gander-tools/diff-voyager-backend",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    },
+    "packages/frontend": {
+      "package-name": "@gander-tools/diff-voyager-frontend",
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
- Rename packages to @gander-tools/diff-voyager-* pattern
  - @gander-tools/diff-voyager-shared
  - @gander-tools/diff-voyager-backend
  - @gander-tools/diff-voyager-frontend
- Reset all package versions to 0.0.0
- Update root package.json workspace references
- Fix release-please-config.json for monorepo setup
  - Configure separate entries for each package
  - Remove incorrect root "." configuration
- Update .release-please-manifest.json to track individual packages