### PR TITLE
Add dependency review workflow for pull requests

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,64 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  # Detect which files changed to conditionally run dependency review
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      dependencies: ${{ steps.filter.outputs.dependencies }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Check for file changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            dependencies:
+              - 'package.json'
+              - 'package-lock.json'
+
+  dependency-review:
+    needs: changes
+    if: needs.changes.outputs.dependencies == 'true'
+    name: Review Dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        with:
+          # Fail the build on moderate or higher vulnerabilities
+          fail-on-severity: moderate
+          # Warn on OpenSSF Scorecard below this level (but don't fail)
+          warn-on-openssf-scorecard-level: 3
+          # Deny specific licenses (example: copyleft licenses if needed)
+          # deny-licenses: GPL-2.0, LGPL-2.0
+          # Allow specific licenses
+          # allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC
+          # Deny packages from specific sources
+          deny-packages: ''
+          # Comment on PR with results
+          comment-summary-in-pr: always
+          # Show dependency changes including OpenSSF Scorecard
+          show-openssf-scorecard: true
+          # Don't use warn-only mode (we want to fail on critical issues)
+          warn-only: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           filters: |
             dependencies:
-              - 'package.json'
-              - 'package-lock.json'
+              - '**/package.json'
+              - '**/package-lock.json'
 
   dependency-review:
     needs: changes


### PR DESCRIPTION
- Automatically scans dependencies for security vulnerabilities
- Fails on moderate or higher severity issues
- Warns on low OpenSSF Scorecard ratings
- Only runs when package.json or package-lock.json change
- Adapted for main branch