### PR TITLE
Add GitHub PR/issue labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,120 @@
+version: 1
+
+labels:
+  # Label PRs from claude/ branches
+  - label: "claude code"
+    branch: "^claude/.*"
+
+  # Label PRs from renovate/ branches
+  - label: "renovate"
+    branch: "^renovate/.*"
+
+  # Documentation changes
+  - label: "documentation"
+    files:
+      - "docs/.*"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CLAUDE.md"
+      - ".claude/.*"
+
+  # Test changes
+  - label: "tests"
+    files:
+      - "tests/.*"
+      - "packages/.*/tests/.*"
+      - "packages/.*/__tests__/.*"
+      - "packages/.*/.*.test.ts"
+      - "packages/.*/.*.spec.ts"
+
+  # GitHub workflows and CI/CD
+  - label: "github-actions"
+    files:
+      - ".github/workflows/.*"
+      - ".github/labeler.yml"
+
+  # Dependency updates
+  - label: "dependencies"
+    files:
+      - "package.json"
+      - "package-lock.json"
+      - "packages/.*/package.json"
+      - "packages/frontend/bun.lockb"
+
+  # Backend changes
+  - label: "backend"
+    files:
+      - "packages/backend/.*"
+
+  # Frontend changes
+  - label: "frontend"
+    files:
+      - "packages/frontend/.*"
+
+  # Shared types/code changes
+  - label: "shared"
+    files:
+      - "packages/shared/.*"
+
+  # Core source code changes (any package)
+  - label: "core"
+    files:
+      - "packages/.*/src/.*"
+
+  # Configuration files
+  - label: "configuration"
+    files:
+      - "tsconfig.*\\.json"
+      - "biome.json"
+      - ".nvmrc"
+      - ".node-version"
+      - "packages/.*/tsconfig.*\\.json"
+
+  # PR size labels - small (< 50 lines)
+  - label: "size/small"
+    size:
+      below: 50
+      exclude-files:
+        - "package-lock.json"
+        - "bun.lockb"
+        - "CHANGELOG.md"
+
+  # PR size labels - medium (50-200 lines)
+  - label: "size/medium"
+    size:
+      above: 49
+      below: 201
+      exclude-files:
+        - "package-lock.json"
+        - "bun.lockb"
+        - "CHANGELOG.md"
+
+  # PR size labels - large (200-500 lines)
+  - label: "size/large"
+    size:
+      above: 199
+      below: 501
+      exclude-files:
+        - "package-lock.json"
+        - "bun.lockb"
+        - "CHANGELOG.md"
+
+  # PR size labels - xlarge (> 500 lines)
+  - label: "size/xlarge"
+    size:
+      above: 500
+      exclude-files:
+        - "package-lock.json"
+        - "bun.lockb"
+        - "CHANGELOG.md"
+
+  # Draft PRs
+  - label: "work-in-progress"
+    draft: true
+
+  # Release-related changes
+  - label: "release"
+    files:
+      - ".github/workflows/release-.*"
+      - ".github/workflows/publish-.*"
+      - ".changeset/.*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Label Manager
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Apply labels
+        uses: srvaroa/labeler@0a20eccb8c94a1ee0bed5f16859aece1c45c3e55 # v1.13.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add Label Manager workflow that auto-labels PRs and issues
- Configure labeler for diff-voyager monorepo structure
- Support branch-based labels (claude code, renovate)
- Add package-specific labels (backend, frontend, shared)
- Include size-based labels and work-in-progress detection
- Adapted from osm-tagging-schema-mcp project