### PR TITLE
chore(config): update Claude settings to new hooks format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,18 @@
 {
-	"$schema": "https://json.schemastore.org/claude-code-settings.json",
-	"allowedTools": ["Skill"],
-	"hooks": {
-		"SessionStart": {
-			"command": "npm install -g npm@11.7.0 && cd \"$CLAUDE_PROJECT_DIR\" && npm install",
-			"timeout": 300000
-		}
-	}
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "allowedTools": ["Skill"],
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "command": "npm install -g npm@11.7.0 && cd \"$CLAUDE_PROJECT_DIR\" && npm install",
+            "timeout": 300000,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Update `.claude/settings.json` to use the new array-based hooks format with matchers, aligning with the latest Claude Code settings schema.

## Changes

- Migrated `SessionStart` hook from simple object format to new array-based format
- Added `matcher` configuration for startup hook
- Specified hook `type` as `"command"`
- Updated formatting to match schema requirements

## Before
```json
"hooks": {
  "SessionStart": {
    "command": "npm install -g npm@11.7.0 && cd \"$CLAUDE_PROJECT_DIR\" && npm install",
    "timeout": 300000
  }
}
```

## After
```json
"hooks": {
  "SessionStart": [
    {
      "matcher": "startup",
      "hooks": [
        {
          "command": "npm install -g npm@11.7.0 && cd \"$CLAUDE_PROJECT_DIR\" && npm install",
          "timeout": 300000,
          "type": "command"
        }
      ]
    }
  ]
}
```

## Test plan

- [x] Settings file syntax is valid JSON
- [x] Verify SessionStart hook still executes correctly
- [x] Confirm npm installation runs at session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)