### PR TITLE
chore(ci): add paths-ignore to CI workflow for documentation-only changes

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - 'claude/**'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,23 @@ on:
     branches:
       - main
       - 'claude/**'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 # Cancel in-progress runs for the same PR/branch
 concurrency:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: write


### PR DESCRIPTION
## 📝 Commits

- chore(ci): add paths-ignore to release-please workflow to skip documentation-only changes%0A- chore(ci): add paths-ignore to auto-pr workflow to skip documentation-only changes%0A- chore(ci): add paths-ignore to CI workflow for documentation-only changes