### PR TITLE
fix(frontend): resolve Vue 3 component import errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,47 @@ bun run dev              # Start dev server
 bun test                 # Run tests
 ```
 
+#### Common Frontend Issues
+
+**Vue 3 Component Resolution Errors**
+
+If you see console errors like:
+```
+[Vue warn]: Failed to resolve component: NButton
+[Vue warn]: Failed to resolve component: DefaultLayout
+```
+
+**Root Cause**: Vue 3 requires explicit imports for all components. Components cannot be used in templates without importing them first.
+
+**Solution**: Add explicit imports at the top of the `<script setup>` section:
+
+```typescript
+// For Naive UI components
+import { NButton, NCard, NLayout } from 'naive-ui';
+
+// For custom components
+import DefaultLayout from './components/layouts/DefaultLayout.vue';
+
+// For router components
+import { RouterView } from 'vue-router';
+```
+
+**Note on @vicons/tabler**: Ensure the package is installed:
+```bash
+npm install @vicons/tabler
+```
+
+Available icon names can be found in `node_modules/@vicons/tabler/es/`. Common icons:
+- `Dashboard`, `Settings`, `Filter`
+- `Folder` (note: `FolderOpen` does not exist)
+- `Globe`, `Moon`, `Sun`
+- `PlaylistAdd`, `Playlist`
+
+Import icons with exact PascalCase names:
+```typescript
+import { Dashboard, Filter, Folder } from '@vicons/tabler';
+```
+
 ### Shared Types
 ```bash
 cd packages/shared

--- a/package-lock.json
+++ b/package-lock.json
@@ -10907,6 +10907,7 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@gander-tools/diff-voyager-shared": "*",
+				"@vicons/tabler": "^0.13.0",
 				"@vitest/ui": "^4.0.16",
 				"@vueuse/core": "^14.1.0",
 				"date-fns": "^4.1.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,6 +39,7 @@
 	},
 	"dependencies": {
 		"@gander-tools/diff-voyager-shared": "*",
+		"@vicons/tabler": "^0.13.0",
 		"@vitest/ui": "^4.0.16",
 		"@vueuse/core": "^14.1.0",
 		"date-fns": "^4.1.0",

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NConfigProvider, NDialogProvider, NMessageProvider } from 'naive-ui';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import { RouterView } from 'vue-router';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import DefaultLayout from './components/layouts/DefaultLayout.vue';
 
 // Naive UI theme configuration

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { NConfigProvider, NDialogProvider, NMessageProvider } from 'naive-ui';
+import { RouterView } from 'vue-router';
+import DefaultLayout from './components/layouts/DefaultLayout.vue';
+
 // Naive UI theme configuration
 // biome-ignore lint/correctness/noUnusedVariables: used in template
 const themeOverrides = {

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NConfigProvider, NDialogProvider, NMessageProvider } from 'naive-ui';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { RouterView } from 'vue-router';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import DefaultLayout from './components/layouts/DefaultLayout.vue';
 
 // Naive UI theme configuration

--- a/packages/frontend/src/components/common/ConfirmDialog.vue
+++ b/packages/frontend/src/components/common/ConfirmDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NButton, NModal, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/frontend/src/components/common/ConfirmDialog.vue
+++ b/packages/frontend/src/components/common/ConfirmDialog.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NButton, NModal, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/frontend/src/components/common/ConfirmDialog.vue
+++ b/packages/frontend/src/components/common/ConfirmDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NButton, NModal, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 
 interface Props {
@@ -11,7 +12,7 @@ interface Props {
   type?: 'default' | 'error' | 'warning' | 'success';
 }
 
-const _props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   loading: false,
   type: 'default',
 });

--- a/packages/frontend/src/components/common/EmptyState.vue
+++ b/packages/frontend/src/components/common/EmptyState.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { NEmpty } from 'naive-ui';
+
 interface Props {
   description?: string;
   size?: 'small' | 'medium' | 'large' | 'huge';

--- a/packages/frontend/src/components/common/EmptyState.vue
+++ b/packages/frontend/src/components/common/EmptyState.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NEmpty } from 'naive-ui';
 
 interface Props {

--- a/packages/frontend/src/components/common/EmptyState.vue
+++ b/packages/frontend/src/components/common/EmptyState.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NEmpty } from 'naive-ui';
 
 interface Props {

--- a/packages/frontend/src/components/common/ErrorAlert.vue
+++ b/packages/frontend/src/components/common/ErrorAlert.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NAlert } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/frontend/src/components/common/ErrorAlert.vue
+++ b/packages/frontend/src/components/common/ErrorAlert.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NAlert } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/packages/frontend/src/components/common/ErrorAlert.vue
+++ b/packages/frontend/src/components/common/ErrorAlert.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NAlert } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/packages/frontend/src/components/common/LoadingSpinner.vue
+++ b/packages/frontend/src/components/common/LoadingSpinner.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { NSpin } from 'naive-ui';
+
 interface Props {
   size?: 'small' | 'medium' | 'large';
   description?: string;

--- a/packages/frontend/src/components/common/LoadingSpinner.vue
+++ b/packages/frontend/src/components/common/LoadingSpinner.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NSpin } from 'naive-ui';
 
 interface Props {

--- a/packages/frontend/src/components/common/LoadingSpinner.vue
+++ b/packages/frontend/src/components/common/LoadingSpinner.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NSpin } from 'naive-ui';
 
 interface Props {

--- a/packages/frontend/src/components/common/Pagination.vue
+++ b/packages/frontend/src/components/common/Pagination.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NPagination } from 'naive-ui';
 import { computed } from 'vue';
 
@@ -21,15 +20,12 @@ const emit = defineEmits<{
   'update:pageSize': [value: number];
 }>();
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const pageCount = computed(() => Math.ceil(props.total / props.pageSize));
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handlePageChange(page: number) {
   emit('update:page', page);
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handlePageSizeChange(pageSize: number) {
   emit('update:pageSize', pageSize);
   // Reset to page 1 when changing page size

--- a/packages/frontend/src/components/common/Pagination.vue
+++ b/packages/frontend/src/components/common/Pagination.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NPagination } from 'naive-ui';
 import { computed } from 'vue';
 
 interface Props {
@@ -19,13 +20,13 @@ const emit = defineEmits<{
   'update:pageSize': [value: number];
 }>();
 
-const _pageCount = computed(() => Math.ceil(props.total / props.pageSize));
+const pageCount = computed(() => Math.ceil(props.total / props.pageSize));
 
-function _handlePageChange(page: number) {
+function handlePageChange(page: number) {
   emit('update:page', page);
 }
 
-function _handlePageSizeChange(pageSize: number) {
+function handlePageSizeChange(pageSize: number) {
   emit('update:pageSize', pageSize);
   // Reset to page 1 when changing page size
   if (props.page !== 1) {

--- a/packages/frontend/src/components/common/Pagination.vue
+++ b/packages/frontend/src/components/common/Pagination.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NPagination } from 'naive-ui';
 import { computed } from 'vue';
 
@@ -20,12 +21,15 @@ const emit = defineEmits<{
   'update:pageSize': [value: number];
 }>();
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const pageCount = computed(() => Math.ceil(props.total / props.pageSize));
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handlePageChange(page: number) {
   emit('update:page', page);
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handlePageSizeChange(pageSize: number) {
   emit('update:pageSize', pageSize);
   // Reset to page 1 when changing page size

--- a/packages/frontend/src/components/layouts/AppBreadcrumb.vue
+++ b/packages/frontend/src/components/layouts/AppBreadcrumb.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NBreadcrumb, NBreadcrumbItem } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -14,7 +13,6 @@ interface BreadcrumbItem {
   path?: string;
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   const items: BreadcrumbItem[] = [];
   const pathSegments = route.path.split('/').filter(Boolean);
@@ -55,7 +53,6 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   return items;
 });
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleClick(path?: string) {
   if (path && path !== route.path) {
     router.push(path);

--- a/packages/frontend/src/components/layouts/AppBreadcrumb.vue
+++ b/packages/frontend/src/components/layouts/AppBreadcrumb.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NBreadcrumb, NBreadcrumbItem } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -12,7 +13,7 @@ interface BreadcrumbItem {
   path?: string;
 }
 
-const _breadcrumbs = computed<BreadcrumbItem[]>(() => {
+const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   const items: BreadcrumbItem[] = [];
   const pathSegments = route.path.split('/').filter(Boolean);
 
@@ -52,7 +53,7 @@ const _breadcrumbs = computed<BreadcrumbItem[]>(() => {
   return items;
 });
 
-function _handleClick(path?: string) {
+function handleClick(path?: string) {
   if (path && path !== route.path) {
     router.push(path);
   }

--- a/packages/frontend/src/components/layouts/AppBreadcrumb.vue
+++ b/packages/frontend/src/components/layouts/AppBreadcrumb.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NBreadcrumb, NBreadcrumbItem } from 'naive-ui';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -13,6 +14,7 @@ interface BreadcrumbItem {
   path?: string;
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   const items: BreadcrumbItem[] = [];
   const pathSegments = route.path.split('/').filter(Boolean);
@@ -53,6 +55,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
   return items;
 });
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleClick(path?: string) {
   if (path && path !== route.path) {
     router.push(path);

--- a/packages/frontend/src/components/layouts/AppHeader.vue
+++ b/packages/frontend/src/components/layouts/AppHeader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: icons used in render functions and template
 import { Globe, Moon, Sun } from '@vicons/tabler';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import { NButton, NDropdown, NIcon, NLayoutHeader, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { availableLocales } from '@/i18n';
@@ -11,25 +10,21 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const uiStore = useUiStore();
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const languageOptions = availableLocales.map((locale) => ({
   label: locale.name,
   key: locale.code,
 }));
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const themeOptions = [
   { label: t('settings.theme.light'), key: 'light' as Theme, icon: Sun },
   { label: t('settings.theme.dark'), key: 'dark' as Theme, icon: Moon },
   { label: t('settings.theme.auto'), key: 'auto' as Theme, icon: Globe },
 ];
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleLanguageSelect(key: string) {
   uiStore.setLanguage(key as 'en' | 'pl');
 }
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleThemeSelect(key: string) {
   uiStore.setTheme(key as Theme);
 }

--- a/packages/frontend/src/components/layouts/AppHeader.vue
+++ b/packages/frontend/src/components/layouts/AppHeader.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: icons used in render functions and template
 import { Globe, Moon, Sun } from '@vicons/tabler';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NButton, NDropdown, NIcon, NLayoutHeader, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { availableLocales } from '@/i18n';
@@ -9,21 +11,25 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const uiStore = useUiStore();
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const languageOptions = availableLocales.map((locale) => ({
   label: locale.name,
   key: locale.code,
 }));
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const themeOptions = [
   { label: t('settings.theme.light'), key: 'light' as Theme, icon: Sun },
   { label: t('settings.theme.dark'), key: 'dark' as Theme, icon: Moon },
   { label: t('settings.theme.auto'), key: 'auto' as Theme, icon: Globe },
 ];
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleLanguageSelect(key: string) {
   uiStore.setLanguage(key as 'en' | 'pl');
 }
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleThemeSelect(key: string) {
   uiStore.setTheme(key as Theme);
 }

--- a/packages/frontend/src/components/layouts/AppHeader.vue
+++ b/packages/frontend/src/components/layouts/AppHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Globe, Moon, Sun } from '@vicons/tabler';
+import { NButton, NDropdown, NIcon, NLayoutHeader, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { availableLocales } from '@/i18n';
 import type { Theme } from '@/stores/ui';
@@ -8,22 +9,22 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const uiStore = useUiStore();
 
-const _languageOptions = availableLocales.map((locale) => ({
+const languageOptions = availableLocales.map((locale) => ({
   label: locale.name,
   key: locale.code,
 }));
 
-const _themeOptions = [
+const themeOptions = [
   { label: t('settings.theme.light'), key: 'light' as Theme, icon: Sun },
   { label: t('settings.theme.dark'), key: 'dark' as Theme, icon: Moon },
   { label: t('settings.theme.auto'), key: 'auto' as Theme, icon: Globe },
 ];
 
-function _handleLanguageSelect(key: string) {
+function handleLanguageSelect(key: string) {
   uiStore.setLanguage(key as 'en' | 'pl');
 }
 
-function _handleThemeSelect(key: string) {
+function handleThemeSelect(key: string) {
   uiStore.setTheme(key as Theme);
 }
 </script>

--- a/packages/frontend/src/components/layouts/AppSidebar.vue
+++ b/packages/frontend/src/components/layouts/AppSidebar.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: icons used in render functions
 import { Dashboard, Filter, Folder, PlaylistAdd, Settings } from '@vicons/tabler';
 import type { MenuOption } from 'naive-ui';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import { NIcon, NLayoutSider, NMenu } from 'naive-ui';
 import { computed, h } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -12,10 +11,9 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
-// biome-ignore lint/correctness/noUnusedVariables: used in template
+
 const uiStore = useUiStore();
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const menuOptions = computed<MenuOption[]>(() => [
   {
     label: t('nav.dashboard'),
@@ -44,7 +42,6 @@ const menuOptions = computed<MenuOption[]>(() => [
   },
 ]);
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 const activeKey = computed(() => {
   // Match the current route path to menu key
   const path = route.path;
@@ -61,7 +58,6 @@ const activeKey = computed(() => {
   return '/';
 });
 
-// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleMenuSelect(key: string) {
   router.push(key);
 }

--- a/packages/frontend/src/components/layouts/AppSidebar.vue
+++ b/packages/frontend/src/components/layouts/AppSidebar.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: icons used in render functions
 import { Dashboard, Filter, Folder, PlaylistAdd, Settings } from '@vicons/tabler';
 import type { MenuOption } from 'naive-ui';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NIcon, NLayoutSider, NMenu } from 'naive-ui';
 import { computed, h } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -10,8 +12,10 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const uiStore = useUiStore();
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const menuOptions = computed<MenuOption[]>(() => [
   {
     label: t('nav.dashboard'),
@@ -40,6 +44,7 @@ const menuOptions = computed<MenuOption[]>(() => [
   },
 ]);
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 const activeKey = computed(() => {
   // Match the current route path to menu key
   const path = route.path;
@@ -56,6 +61,7 @@ const activeKey = computed(() => {
   return '/';
 });
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template
 function handleMenuSelect(key: string) {
   router.push(key);
 }

--- a/packages/frontend/src/components/layouts/AppSidebar.vue
+++ b/packages/frontend/src/components/layouts/AppSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { Dashboard, Filter, FolderOpen, PlaylistAdd, Settings } from '@vicons/tabler';
+import { Dashboard, Filter, Folder, PlaylistAdd, Settings } from '@vicons/tabler';
 import type { MenuOption } from 'naive-ui';
-import { NIcon } from 'naive-ui';
+import { NIcon, NLayoutSider, NMenu } from 'naive-ui';
 import { computed, h } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -10,9 +10,9 @@ import { useUiStore } from '@/stores/ui';
 const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
-const _uiStore = useUiStore();
+const uiStore = useUiStore();
 
-const _menuOptions = computed<MenuOption[]>(() => [
+const menuOptions = computed<MenuOption[]>(() => [
   {
     label: t('nav.dashboard'),
     key: '/',
@@ -21,7 +21,7 @@ const _menuOptions = computed<MenuOption[]>(() => [
   {
     label: t('nav.projects'),
     key: '/projects',
-    icon: () => h(NIcon, null, { default: () => h(FolderOpen) }),
+    icon: () => h(NIcon, null, { default: () => h(Folder) }),
   },
   {
     label: t('nav.runs'),
@@ -40,7 +40,7 @@ const _menuOptions = computed<MenuOption[]>(() => [
   },
 ]);
 
-const _activeKey = computed(() => {
+const activeKey = computed(() => {
   // Match the current route path to menu key
   const path = route.path;
 
@@ -56,7 +56,7 @@ const _activeKey = computed(() => {
   return '/';
 });
 
-function _handleMenuSelect(key: string) {
+function handleMenuSelect(key: string) {
   router.push(key);
 }
 </script>

--- a/packages/frontend/src/components/layouts/DefaultLayout.vue
+++ b/packages/frontend/src/components/layouts/DefaultLayout.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NLayout, NLayoutContent } from 'naive-ui';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import AppBreadcrumb from './AppBreadcrumb.vue';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import AppHeader from './AppHeader.vue';
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import AppSidebar from './AppSidebar.vue';
 </script>
 

--- a/packages/frontend/src/components/layouts/DefaultLayout.vue
+++ b/packages/frontend/src/components/layouts/DefaultLayout.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NLayout, NLayoutContent } from 'naive-ui';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import AppBreadcrumb from './AppBreadcrumb.vue';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import AppHeader from './AppHeader.vue';
-// biome-ignore lint/correctness/noUnusedImports: used in template
+
 import AppSidebar from './AppSidebar.vue';
 </script>
 

--- a/packages/frontend/src/components/layouts/DefaultLayout.vue
+++ b/packages/frontend/src/components/layouts/DefaultLayout.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-
+import { NLayout, NLayoutContent } from 'naive-ui';
+import AppBreadcrumb from './AppBreadcrumb.vue';
+import AppHeader from './AppHeader.vue';
+import AppSidebar from './AppSidebar.vue';
 </script>
 
 <template>

--- a/packages/frontend/src/views/DashboardView.vue
+++ b/packages/frontend/src/views/DashboardView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NCard } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 
 // biome-ignore lint/correctness/noUnusedVariables: used in template

--- a/packages/frontend/src/views/DashboardView.vue
+++ b/packages/frontend/src/views/DashboardView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NCard } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/frontend/src/views/DashboardView.vue
+++ b/packages/frontend/src/views/DashboardView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NCard } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 

--- a/packages/frontend/src/views/NotFoundView.vue
+++ b/packages/frontend/src/views/NotFoundView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NButton, NCard, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';

--- a/packages/frontend/src/views/NotFoundView.vue
+++ b/packages/frontend/src/views/NotFoundView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// biome-ignore lint/correctness/noUnusedImports: used in template
 import { NButton, NCard, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';

--- a/packages/frontend/src/views/NotFoundView.vue
+++ b/packages/frontend/src/views/NotFoundView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { NButton, NCard, NSpace } from 'naive-ui';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 


### PR DESCRIPTION
## Summary

Fixed critical Vue 3 component resolution errors that prevented the frontend application from rendering. The application was showing unstyled content with console errors due to missing component imports.

### Root Cause
Vue 3 requires explicit imports for all components used in templates. Components were being used without proper imports, causing Vue to fail component resolution.

### Changes Made

1. **Installed missing dependency** (`@vicons/tabler`)
   - Package was referenced in code but not in package.json
   
2. **Added explicit component imports** across all Vue files:
   - Naive UI components (NButton, NCard, NLayout, NMenu, etc.)
   - Custom layout components (DefaultLayout, AppHeader, AppSidebar, AppBreadcrumb)
   - Router components (RouterView)
   
3. **Fixed icon imports**:
   - Changed `FolderOpen` to `Folder` (FolderOpen doesn't exist in @vicons/tabler)
   - Verified all icon names against available exports
   
4. **Code cleanup**:
   - Removed underscore prefixes from variables to match template usage
   - Ensured consistency across all components

5. **Documentation**:
   - Added troubleshooting section to CLAUDE.md
   - Documented common Vue 3 component import patterns
   - Listed available @vicons/tabler icon names

### Files Changed
- `App.vue` - Added core provider and layout imports
- Layout components (4 files) - Added Naive UI and icon imports
- View components (2 files) - Added Naive UI imports
- Common components (5 files) - Added Naive UI imports
- `package.json` - Added @vicons/tabler dependency
- `CLAUDE.md` - Added troubleshooting guide

## Test Plan

- [x] Application renders without console errors
- [x] Navigation sidebar displays with icons
- [x] Header with language/theme switchers renders
- [x] Breadcrumb navigation works
- [x] Dashboard view displays properly
- [x] All layout components render correctly
- [x] Theme and language switches function
- [x] 404 page renders with styled error message

## Before/After

**Before**: Console showed multiple "Failed to resolve component" errors, page showed unstyled text

**After**: Application renders with full layout, navigation, styling, and interactive components

🤖 Generated with [Claude Code](https://claude.com/claude-code)