### PR TITLE
fix(frontend): remove non-null assertion operators

### DIFF
--- a/packages/frontend/src/stores/projects.ts
+++ b/packages/frontend/src/stores/projects.ts
@@ -98,7 +98,9 @@ export const useProjectsStore = defineStore('projects', {
      * Get ordered list of projects
      */
     projectList: (state): ProjectListItem[] => {
-      return state.list.map((id) => state.items.get(id)!).filter(Boolean);
+      return state.list
+        .map((id) => state.items.get(id))
+        .filter((item): item is ProjectListItem => item !== undefined);
     },
 
     /**
@@ -121,8 +123,8 @@ export const useProjectsStore = defineStore('projects', {
       (state) =>
       (limit = 5): ProjectListItem[] => {
         return state.list
-          .map((id) => state.items.get(id)!)
-          .filter(Boolean)
+          .map((id) => state.items.get(id))
+          .filter((item): item is ProjectListItem => item !== undefined)
           .slice(0, limit);
       },
 

--- a/packages/frontend/tests/unit/stores/projects.test.ts
+++ b/packages/frontend/tests/unit/stores/projects.test.ts
@@ -118,7 +118,7 @@ describe('projectsStore', () => {
     });
 
     it('should set loading state during fetch', async () => {
-      let resolveRequest: (value: unknown) => void;
+      let resolveRequest: ((value: unknown) => void) | undefined;
       const requestPromise = new Promise((resolve) => {
         resolveRequest = resolve;
       });
@@ -138,7 +138,7 @@ describe('projectsStore', () => {
 
       expect(store.loading).toBe(true);
 
-      resolveRequest!(null);
+      resolveRequest?.(null);
       await fetchPromise;
 
       expect(store.loading).toBe(false);

--- a/packages/frontend/tests/unit/views/DashboardView.test.ts
+++ b/packages/frontend/tests/unit/views/DashboardView.test.ts
@@ -139,7 +139,7 @@ describe('DashboardView', () => {
   });
 
   it('should display loading state', async () => {
-    let resolveRequest: (value: unknown) => void;
+    let resolveRequest: ((value: unknown) => void) | undefined;
     const requestPromise = new Promise((resolve) => {
       resolveRequest = resolve;
     });
@@ -159,7 +159,7 @@ describe('DashboardView', () => {
 
     expect(wrapper.text()).toContain('Loading');
 
-    resolveRequest!(null);
+    resolveRequest?.(null);
     await new Promise((resolve) => setTimeout(resolve, 100));
   });
 

--- a/packages/frontend/tests/unit/views/ProjectCreateView.test.ts
+++ b/packages/frontend/tests/unit/views/ProjectCreateView.test.ts
@@ -147,7 +147,7 @@ describe('ProjectCreateView', () => {
   });
 
   it('should show loading state during project creation', async () => {
-    let resolveRequest: (value: unknown) => void;
+    let resolveRequest: ((value: unknown) => void) | undefined;
     const requestPromise = new Promise((resolve) => {
       resolveRequest = resolve;
     });
@@ -184,7 +184,7 @@ describe('ProjectCreateView', () => {
 
       expect(wrapper.text()).toContain('Creating');
 
-      resolveRequest!(null);
+      resolveRequest?.(null);
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
   });


### PR DESCRIPTION
## Summary

This PR removes all non-null assertion operators (`!`) from the frontend codebase to satisfy Biome linting rules and improve type safety.

### What Changed

**Fixed 5 Biome warnings** (`lint/style/noNonNullAssertion`):

1. **stores/projects.ts** (2 warnings):
   - `projectList` getter: Replaced `.map(id => state.items.get(id)!).filter(Boolean)` with type-safe filter using type guard
   - `recentProjects` getter: Same fix applied

2. **Test files** (3 warnings):
   - Changed `resolveRequest` type from `(value: unknown) => void` to `((value: unknown) => void) | undefined`
   - Replaced `resolveRequest!(null)` with `resolveRequest?.(null)` using optional chaining

### Before (Non-null Assertion)

```typescript
// stores/projects.ts
projectList: (state): ProjectListItem[] => {
  return state.list.map((id) => state.items.get(id)!).filter(Boolean);
}

// tests
let resolveRequest: (value: unknown) => void;
// ...
resolveRequest!(null);  // ⚠️ Non-null assertion warning
```

### After (Type-safe)

```typescript
// stores/projects.ts
projectList: (state): ProjectListItem[] => {
  return state.list
    .map((id) => state.items.get(id))
    .filter((item): item is ProjectListItem => item !== undefined);
}

// tests
let resolveRequest: ((value: unknown) => void) | undefined;
// ...
resolveRequest?.(null);  // ✅ Optional chaining - type safe
```

### Benefits

- **Zero Biome warnings**: All 165 files checked, 0 issues
- **Better type safety**: Explicit handling of `undefined` instead of assuming values exist
- **TypeScript type guards**: Proper type narrowing in filters
- **Safer tests**: Optional chaining prevents runtime errors if callback not set

### Testing

- ✅ All 167 frontend tests passing
- ✅ Biome check: 0 errors, 0 warnings
- ✅ Type checking: No TypeScript errors

## Test plan

- [x] Run Biome linting: `npx biome check .`
- [x] Run all frontend tests: `npm test`
- [x] Verify no TypeScript errors: `npm run type-check`
- [ ] Quick smoke test in browser (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)