### PR TITLE
feat: configurable log levels for console and file outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,27 @@ npm run dev:backend
 
 # Or with custom port/data directory
 PORT=3001 DATA_DIR=./my-data npm run dev:backend
+
+# Configure log levels via environment variables
+LOG_LEVEL_CONSOLE=info LOG_LEVEL_FILE=debug npm run dev:backend
+
+# Or via CLI arguments (takes priority over env vars)
+node packages/backend/dist/index.js --log-level-console info --log-level-file debug
+
+# All available options
+node packages/backend/dist/index.js \
+  --port 3001 \
+  --data-dir ./my-data \
+  --log-level-console warn \
+  --log-level-file debug
 ```
+
+**Log Level Configuration:**
+- **Environment variables:** `LOG_LEVEL_CONSOLE`, `LOG_LEVEL_FILE` (or `LOG_LEVEL` for both)
+- **CLI flags:** `--log-level-console`, `--log-level-file` (or `--log-level` for both)
+- **Priority:** CLI flags > environment variables > defaults
+- **Valid levels:** `trace`, `debug`, `info`, `warn`, `error`, `fatal`
+- **Defaults:** Console=`debug` (dev) or `info` (prod), File=`debug`
 
 The server will be available at `http://localhost:3000` with endpoints:
 - `POST /api/v1/scans` - Create a scan (single page or crawl)

--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -29,9 +29,21 @@ export interface AppConfig {
   taskQueue?: TaskQueue; // Optional - will be created if not provided
   logLevelConsole?: string; // Console log level (default: debug in dev, info in prod)
   logLevelFile?: string; // File log level (default: debug)
+  disableLogging?: boolean; // Disable logging entirely (for tests)
 }
 
 export async function createApp(config: AppConfig): Promise<FastifyInstance> {
+  // If logging is disabled (e.g., for tests), create app without logger
+  if (config.disableLogging) {
+    const app = Fastify({
+      logger: false,
+    });
+
+    // Skip logger setup, just register plugins
+    await registerPlugins(app, config);
+    return app;
+  }
+
   // Ensure logs directory exists
   const logsDir = join(process.cwd(), 'data', 'logs');
   await mkdir(logsDir, { recursive: true, mode: 0o700 });
@@ -90,6 +102,17 @@ export async function createApp(config: AppConfig): Promise<FastifyInstance> {
     disableRequestLogging: false,
   });
 
+  // Log configured log levels
+  app.log.info(`Logger configured: console=${logLevelConsole}, file=${logLevelFile}`);
+
+  await registerPlugins(app, config);
+  return app;
+}
+
+/**
+ * Register all Fastify plugins and routes
+ */
+async function registerPlugins(app: FastifyInstance, config: AppConfig) {
   // Register CORS plugin
   await app.register(cors, {
     origin: true, // Allow all origins in development
@@ -223,9 +246,4 @@ export async function createApp(config: AppConfig): Promise<FastifyInstance> {
     prefix: API_BASE_PATH,
     artifactsDir: config.artifactsDir,
   });
-
-  // Log configured log levels
-  app.log.info(`Logger configured: console=${logLevelConsole}, file=${logLevelFile}`);
-
-  return app;
 }

--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -2,12 +2,15 @@
  * Fastify application setup
  */
 
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
 import { API_BASE_PATH } from '@gander-tools/diff-voyager-shared';
 import Fastify, { type FastifyInstance } from 'fastify';
+import { stdSerializers } from 'pino';
 import { TaskQueue } from '../queue/task-queue.js';
 import type { DatabaseInstance } from '../storage/database.js';
 import type { DrizzleDb } from '../storage/drizzle/db.js';
@@ -24,11 +27,67 @@ export interface AppConfig {
   drizzleDb: DrizzleDb;
   artifactsDir: string;
   taskQueue?: TaskQueue; // Optional - will be created if not provided
+  logLevelConsole?: string; // Console log level (default: debug in dev, info in prod)
+  logLevelFile?: string; // File log level (default: debug)
 }
 
 export async function createApp(config: AppConfig): Promise<FastifyInstance> {
+  // Ensure logs directory exists
+  const logsDir = join(process.cwd(), 'data', 'logs');
+  await mkdir(logsDir, { recursive: true, mode: 0o700 });
+
+  // Configure Pino logger with multiple transports
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+  const defaultLogLevel = isDevelopment ? 'debug' : 'info';
+
+  // Use provided log levels or defaults
+  const logLevelConsole = config.logLevelConsole || defaultLogLevel;
+  const logLevelFile = config.logLevelFile || 'debug';
+
+  // The base logger level must be the lowest of all transports
+  const baseLogLevel =
+    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].indexOf(logLevelConsole) <
+    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].indexOf(logLevelFile)
+      ? logLevelConsole
+      : logLevelFile;
+
   const app = Fastify({
-    logger: false,
+    logger: {
+      level: baseLogLevel,
+      // Serialize errors with full stack trace
+      serializers: {
+        err: stdSerializers.err,
+        error: stdSerializers.err,
+      },
+      transport: {
+        targets: [
+          // Console transport with pino-pretty (colored, human-readable)
+          {
+            target: 'pino-pretty',
+            level: logLevelConsole,
+            options: {
+              colorize: true,
+              translateTime: 'SYS:HH:MM:ss',
+              ignore: 'pid,hostname',
+              singleLine: false,
+              // Show minimal info in console, full details in file
+              errorLikeObjectKeys: ['err', 'error'],
+            },
+          },
+          // File transport with full error stack traces
+          {
+            target: 'pino/file',
+            level: logLevelFile,
+            options: {
+              destination: join(logsDir, 'app.log'),
+              mkdir: true,
+            },
+          },
+        ],
+      },
+    },
+    // Disable request logging for health checks (too noisy)
+    disableRequestLogging: false,
   });
 
   // Register CORS plugin
@@ -164,6 +223,9 @@ export async function createApp(config: AppConfig): Promise<FastifyInstance> {
     prefix: API_BASE_PATH,
     artifactsDir: config.artifactsDir,
   });
+
+  // Log configured log levels
+  app.log.info(`Logger configured: console=${logLevelConsole}, file=${logLevelFile}`);
 
   return app;
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -13,9 +13,41 @@ import { createDrizzleDb } from './storage/drizzle/db.js';
 const DEFAULT_PORT = 3000;
 const DEFAULT_DATA_DIR = './data';
 
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string | undefined> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = args[i + 1];
+      if (value && !value.startsWith('--')) {
+        parsed[key] = value;
+        i++; // Skip next arg as it's the value
+      }
+    }
+  }
+
+  return parsed;
+}
+
 async function main() {
-  const port = Number(process.env.PORT) || DEFAULT_PORT;
-  const dataDir = process.env.DATA_DIR || DEFAULT_DATA_DIR;
+  const args = parseArgs();
+
+  const port = Number(args.port || process.env.PORT) || DEFAULT_PORT;
+  const dataDir = args['data-dir'] || process.env.DATA_DIR || DEFAULT_DATA_DIR;
+
+  // Parse log levels with priority: CLI args > env vars > defaults
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+  const defaultLogLevel = isDevelopment ? 'debug' : 'info';
+
+  const logLevel = args['log-level'] || process.env.LOG_LEVEL || defaultLogLevel;
+  const logLevelConsole = args['log-level-console'] || process.env.LOG_LEVEL_CONSOLE || logLevel;
+  const logLevelFile = args['log-level-file'] || process.env.LOG_LEVEL_FILE || 'debug';
 
   // Ensure data directories exist with restricted permissions
   const dbPath = join(dataDir, 'diff-voyager.db');
@@ -35,7 +67,13 @@ async function main() {
   console.log('Drizzle ORM initialized');
 
   // Create and start app
-  const app = await createApp({ db, drizzleDb, artifactsDir });
+  const app = await createApp({
+    db,
+    drizzleDb,
+    artifactsDir,
+    logLevelConsole,
+    logLevelFile,
+  });
 
   await app.listen({ port, host: '0.0.0.0' });
   console.log(`API server running at http://localhost:${port}`);

--- a/packages/backend/tests/helpers/test-db.ts
+++ b/packages/backend/tests/helpers/test-db.ts
@@ -67,6 +67,7 @@ export async function createTestApp(config: {
     drizzleDb,
     artifactsDir: config.artifactsDir,
     taskQueue,
+    disableLogging: true,
   });
   await app.ready();
   return app;

--- a/packages/backend/tests/integration/api/artifacts-endpoint.test.ts
+++ b/packages/backend/tests/integration/api/artifacts-endpoint.test.ts
@@ -15,6 +15,7 @@ import {
   createDatabase,
   type DatabaseInstance,
 } from '../../../src/storage/database.js';
+import { createDrizzleDb } from '../../../src/storage/drizzle/db.js';
 
 // Helper to create a test PNG buffer
 function createTestImage(
@@ -65,9 +66,10 @@ describe('Artifact Endpoints', () => {
 
     // Create database
     db = createDatabase({ dbPath, baseDir: testDir, artifactsDir });
+    const drizzleDb = createDrizzleDb(db);
 
     // Create app
-    app = await createApp({ db, artifactsDir });
+    app = await createApp({ db, drizzleDb, artifactsDir, disableLogging: true });
     await app.ready();
   });
 

--- a/packages/backend/tests/integration/api/ts-rest-routes.test.ts
+++ b/packages/backend/tests/integration/api/ts-rest-routes.test.ts
@@ -39,7 +39,7 @@ describe('@ts-rest API Routes', () => {
     const drizzleDb = createDrizzleDb(db);
 
     // Create app with @ts-rest routes
-    app = await createApp({ db, drizzleDb, artifactsDir });
+    app = await createApp({ db, drizzleDb, artifactsDir, disableLogging: true });
 
     // Start mock server
     mockServer = new MockServer({


### PR DESCRIPTION
## Summary

Adds support for configuring different log levels for console and file outputs via environment variables or CLI flags.

This allows developers to:
- See only important messages in console (e.g., `warn`) while logging everything to file (`debug`)
- Reduce console noise during development
- Keep detailed logs for debugging without cluttering terminal output
- Configure logging per deployment environment

## Features

**Environment Variables:**
- `LOG_LEVEL_CONSOLE` - Console output log level
- `LOG_LEVEL_FILE` - File output log level  
- `LOG_LEVEL` - Fallback for both (if specific levels not set)

**CLI Flags:**
- `--log-level-console <level>` - Override console log level
- `--log-level-file <level>` - Override file log level
- `--log-level <level>` - Override both levels

**Priority:** CLI flags > Environment variables > Defaults

**Valid Levels:** `trace`, `debug`, `info`, `warn`, `error`, `fatal`

**Defaults:**
- Console: `debug` (development) / `info` (production)
- File: `debug` (always)

## Implementation

### Backend (`packages/backend/src/index.ts`)
- Added `parseArgs()` function to parse CLI arguments
- Extracts log level configuration from CLI or env vars
- Passes log levels to `createApp()`

### Backend (`packages/backend/src/api/app.ts`)
- Added `logLevelConsole` and `logLevelFile` to `AppConfig` interface
- Implemented Pino logger with dual transports:
  - Console transport with pino-pretty (colored, human-readable)
  - File transport with JSON output (full stack traces)
- Base logger level set to lowest of both transports (Pino requirement)
- Startup message logs configured levels

### Documentation (`CLAUDE.md`)
- Added "Log Level Configuration" section
- Usage examples with env vars and CLI flags
- Documented defaults and priority order

## Example Usage

```bash
# Environment variables
LOG_LEVEL_CONSOLE=info LOG_LEVEL_FILE=debug npm run dev

# CLI flags
node packages/backend/dist/index.js --log-level-console warn --log-level-file debug

# Combined with other options
node packages/backend/dist/index.js \
  --port 3001 \
  --data-dir ./my-data \
  --log-level-console info \
  --log-level-file debug
```

## Test Plan

- [x] Parse CLI arguments correctly
- [x] Parse environment variables correctly
- [x] CLI flags override environment variables
- [x] Default values used when not specified
- [x] Console shows only configured level messages
- [x] File logs all messages at configured level
- [x] Startup message displays configured levels
- [x] Manual test: `LOG_LEVEL_CONSOLE=info LOG_LEVEL_FILE=debug npm run dev`
  - Console output filtered to `info` level
  - File contains `debug` level entries
  - Startup message: "Logger configured: console=info, file=debug"

## Benefits

- **Reduced console noise** during development
- **Detailed file logs** for debugging without cluttering terminal
- **Flexible configuration** per environment (dev/staging/prod)
- **No code changes** needed to adjust logging verbosity

🤖 Generated with [Claude Code](https://claude.com/claude-code)