### PR TITLE
docs: update API documentation for retry functionality

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -427,3 +427,95 @@ Content-Type: text/html; charset=utf-8
 | GET | `/artifacts/:pageId/diff` | Get diff image | 3 |
 | GET | `/artifacts/:pageId/har` | Get HAR file | 3 |
 | GET | `/artifacts/:pageId/html` | Get HTML | 3 |
+| POST | `/snapshots/:snapshotId/retry` | Retry failed snapshot | - |
+| POST | `/runs/:runId/retry` | Retry failed pages in run | - |
+
+---
+
+## Retry Endpoints
+
+### POST /snapshots/:snapshotId/retry
+
+Retry capturing a failed snapshot. Re-executes the page capture process for a single snapshot.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `snapshotId` | UUID | Snapshot identifier to retry |
+
+**Request Body:** None (void)
+
+**Response: 202 Accepted**
+
+```json
+{
+  "snapshotId": "550e8400-e29b-41d4-a716-446655440001",
+  "status": "COMPLETED",
+  "message": "Snapshot retried successfully"
+}
+```
+
+**Response: 404 Not Found**
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Snapshot not found"
+  }
+}
+```
+
+---
+
+### POST /runs/:runId/retry
+
+Retry snapshots in a run. Can retry all snapshots or only failed ones based on the `scope` query parameter.
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `runId` | UUID | Run identifier |
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scope` | enum | `failed` | Retry scope: `failed` (only failed snapshots) or `all` (all snapshots) |
+
+**Request Body:** None (void)
+
+**Response: 202 Accepted**
+
+```json
+{
+  "runId": "550e8400-e29b-41d4-a716-446655440002",
+  "status": "COMPLETED",
+  "message": "Retried 5 snapshots: 3 succeeded, 2 failed",
+  "retryCount": 5
+}
+```
+
+**Response: 400 Bad Request**
+
+```json
+{
+  "error": {
+    "code": "NO_SNAPSHOTS",
+    "message": "No failed snapshots to retry"
+  }
+}
+```
+
+**Response: 404 Not Found**
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Run not found"
+  }
+}
+```

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -463,6 +463,32 @@ export interface ArtifactInfo {
   size: number;
   url: string;
 }
+
+/**
+ * Response from retrying a snapshot
+ */
+export interface RetrySnapshotResponse {
+  snapshotId: string;
+  status: string;
+  message: string;
+}
+
+/**
+ * Response from retrying a run
+ */
+export interface RetryRunResponse {
+  runId: string;
+  status: string;
+  message: string;
+  retryCount: number;
+}
+
+/**
+ * Query parameters for retry run endpoint
+ */
+export interface RetryRunQuery {
+  scope?: 'failed' | 'all'; // Default: 'failed'
+}
 ```
 
 ### Storage Layer Types

--- a/docs/development/implementation-status.md
+++ b/docs/development/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-**Last Updated**: 2026-01-09
+**Last Updated**: 2026-01-11
 
 ## Current Phase: Phase 5 Complete ✅ | Frontend Phase 2 Complete ✅
 
@@ -20,6 +20,7 @@ Diff Voyager has completed the core backend implementation with all API endpoint
 | 2026-01-08 | Drizzle ORM migration complete (all 6 repositories) |
 | 2026-01-08 | Frontend Phase 1 complete (Foundation & Infrastructure) |
 | 2026-01-09 | Frontend Phase 2 complete (Project Management UI) |
+| 2026-01-11 | Retry functionality complete (Phase 6) |
 
 ## Phase Completion Overview
 
@@ -30,8 +31,8 @@ Diff Voyager has completed the core backend implementation with all API endpoint
 | **Phase 2** | ✅ Complete | 100% | Domain logic and comparators |
 | **Phase 3** | ✅ Complete | 100% | Crawler and browser automation |
 | **Phase 4** | ✅ Complete | 100% | Task queue and async processing |
-| **Phase 5** | ✅ Complete | 100% | API layer (all 13 endpoints) |
-| **Phase 6** | 🟡 Partial | 50% | Integration workflows |
+| **Phase 5** | ✅ Complete | 100% | API layer (all 15 endpoints) |
+| **Phase 6** | 🟡 Partial | 60% | Integration workflows |
 | **Phase 7** | 🟡 Partial | 50% | Production polish |
 | **Frontend** | 🟡 In Progress | 40% | Vue 3 UI (Phase 1 & 2 Complete) |
 
@@ -49,6 +50,7 @@ Diff Voyager has completed the core backend implementation with all API endpoint
 - ✅ HTML fixtures for SEO testing
 - ✅ Shared TypeScript types (API requests/responses)
 - ✅ Build automation for shared package
+- ✅ Zod schema validation tests (32 tests for shared package schemas)
 
 **Test Coverage**:
 - Unit tests: Comprehensive coverage
@@ -162,7 +164,7 @@ See [Drizzle Migration Guide](../guides/drizzle-migration.md) for details.
 
 ### Phase 5: API Layer ✅ (100%)
 
-**Status**: Complete - All 13 endpoints implemented
+**Status**: Complete - All 15 endpoints implemented
 
 **Completed Endpoints**:
 - ✅ `POST /api/v1/scans` - Create scan (single page, sync/async modes)
@@ -172,8 +174,10 @@ See [Drizzle Migration Guide](../guides/drizzle-migration.md) for details.
 - ✅ `GET /api/v1/projects/:id/runs` - List runs for project
 - ✅ `GET /api/v1/runs/:id` - Run details with statistics
 - ✅ `GET /api/v1/runs/:id/pages` - Pages list with filtering
+- ✅ `POST /api/v1/runs/:runId/retry` - Retry failed pages in run ⚡NEW
 - ✅ `GET /api/v1/pages/:id` - Page details with latest snapshot
 - ✅ `GET /api/v1/pages/:id/diff` - Detailed diff comparison
+- ✅ `POST /api/v1/snapshots/:snapshotId/retry` - Retry failed snapshot ⚡NEW
 - ✅ `GET /api/v1/tasks/:id` - Task status and progress
 - ✅ `GET /api/v1/artifacts/:pageId/*` - Retrieve artifacts (screenshot, HTML, HAR)
 - ✅ `GET /health` - Health check
@@ -194,9 +198,9 @@ See [Drizzle Migration Guide](../guides/drizzle-migration.md) for details.
 **Known Issues**:
 - 3 tests skipped (snapshot data retrieval) - see [Skipped Tests](#skipped-tests)
 
-### Phase 6: Integration & Workflows 🟡 (50%)
+### Phase 6: Integration & Workflows 🟡 (60%)
 
-**Status**: Partial - Core workflows working, diff integration pending
+**Status**: Partial - Core workflows working, retry functionality complete
 
 **Completed**:
 - ✅ ScanProcessor (orchestrates project → run → capture → storage)
@@ -204,6 +208,8 @@ See [Drizzle Migration Guide](../guides/drizzle-migration.md) for details.
 - ✅ Multiple comparison runs per project
 - ✅ Artifact persistence (screenshots, HTML, performance data)
 - ✅ Async task processing integration
+- ✅ Retry functionality for failed snapshots ⚡NEW
+- ✅ Retry functionality for failed runs (all or failed-only scope) ⚡NEW
 
 **Pending**:
 - ⏳ Baseline vs run comparison workflow


### PR DESCRIPTION
## Summary

Updates documentation to reflect recent code changes from 2026-01-09 to 2026-01-11:

- **Retry functionality** - Documents 2 new API endpoints for retrying failed snapshots and runs
- **Implementation status** - Updates dates, milestones, and completion percentages
- **Zod schema validation** - Documents completed test infrastructure

### Changes

**docs/api/endpoints.md** (~90 lines added):
- Added "Retry Endpoints" section with full specifications
- Documented `POST /snapshots/:snapshotId/retry` with request/response examples
- Documented `POST /runs/:runId/retry` with query parameters (`scope: 'failed' | 'all'`)
- Updated API summary table with 2 new endpoints

**docs/api/types.md** (~25 lines added):
- Added `RetrySnapshotResponse` interface
- Added `RetryRunResponse` interface
- Added `RetryRunQuery` interface with scope parameter

**docs/development/implementation-status.md** (~30 lines modified):
- Updated "Last Updated" date: 2026-01-09 → 2026-01-11
- Added milestone: "Retry functionality complete (Phase 6)"
- Phase 0: Added Zod schema validation tests (32 tests)
- Phase 5: Updated from 13 to 15 endpoints (added 2 retry endpoints)
- Phase 6: Updated completion from 50% to 60%
- Phase Overview: Updated Phase 5 and Phase 6 statistics

### Related Commits

This documentation update corresponds to:
- f2cbed7, 6f4fa06 - Retry functionality implementation
- f338d56 - Zod schema validation tests

## Test Plan

- [x] All markdown files are properly formatted
- [x] API endpoint documentation matches api-contract.ts definitions
- [x] Response schemas match backend implementation
- [x] HTTP status codes are accurate (202, 404, 400)
- [x] Error codes match implementation (NOT_FOUND, NO_SNAPSHOTS)
- [x] Query parameter enum values are correct ('failed', 'all')
- [x] Implementation status dates and percentages are current
- [x] Cross-references between docs are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)