### PR TITLE
test(frontend): update Content-Type header tests for void body fix

### DIFF
--- a/packages/frontend/tests/unit/services/api/client.spec.ts
+++ b/packages/frontend/tests/unit/services/api/client.spec.ts
@@ -178,7 +178,7 @@ describe('API Client', () => {
       expect(result.received.name).toBe('test');
     });
 
-    it('should include Content-Type header', async () => {
+    it('should NOT include Content-Type header for GET requests without body', async () => {
       let headers: Headers | undefined;
 
       server.use(
@@ -189,6 +189,20 @@ describe('API Client', () => {
       );
 
       await get('/test-headers');
+      expect(headers?.get('Content-Type')).toBeNull();
+    });
+
+    it('should include Content-Type header for POST requests with body', async () => {
+      let headers: Headers | undefined;
+
+      server.use(
+        http.post(`${API_BASE_URL}/test-headers`, ({ request }) => {
+          headers = request.headers;
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      await post('/test-headers', { data: 'test' });
       expect(headers?.get('Content-Type')).toBe('application/json');
     });
   });


### PR DESCRIPTION
## Summary

Updates API client tests to match the new behavior introduced in commit f56196d where `Content-Type: application/json` header is only set when request body exists.

### Context

The fix in **f56196d** changed the API client to conditionally set `Content-Type` header:
- **Before**: Always set `Content-Type: application/json` for all requests
- **After**: Only set `Content-Type: application/json` when `body` is present (not undefined/null)

This broke one existing test that expected Content-Type on a GET request (which has no body).

### Changes

**File**: `packages/frontend/tests/unit/services/api/client.spec.ts`

**Updated test** (1 test modified):
```typescript
// Before:
it('should include Content-Type header', async () => {
  await get('/test-headers');
  expect(headers?.get('Content-Type')).toBe('application/json'); // ❌ FAIL
});

// After:
it('should NOT include Content-Type header for GET requests without body', async () => {
  await get('/test-headers');
  expect(headers?.get('Content-Type')).toBeNull(); // ✅ PASS
});
```

**New test** (1 test added):
```typescript
it('should include Content-Type header for POST requests with body', async () => {
  await post('/test-headers', { data: 'test' });
  expect(headers?.get('Content-Type')).toBe('application/json'); // ✅ PASS
});
```

### Test Results

**Before this PR**:
```
✓ 20 test files
✗ 1 failed test (Content-Type header assertion)
✓ 166 passed tests
```

**After this PR**:
```
✓ 20 test files passed
✓ 168 tests passed (+2: updated 1, added 1 new)
Duration: 11.51s
```

**Coverage** (unchanged):
```
Statements: 43.85% (400/912)
Branches: 43.62% (171/392)
Functions: 41.74% (139/333)
Lines: 44.26% (378/854)
```

### Why This Matters

The test update ensures our test suite correctly validates the **expected behavior**:

1. ✅ **GET requests** (no body) → NO Content-Type header
   - Prevents Fastify error: "Body cannot be empty when content-type is set"
   - Fixes retry endpoints and delete operations

2. ✅ **POST/PUT requests** (with body) → HAS Content-Type header
   - Normal JSON API requests continue to work
   - No regression in existing functionality

### Related

- **Commit**: f56196d - Original fix for Content-Type conditional logic
- **Issue**: "Body cannot be empty when content-type is set to 'application/json'"
- **Affected endpoints**: 
  - `POST /api/v1/runs/:runId/retry`
  - `POST /api/v1/snapshots/:snapshotId/retry`
  - `DELETE /api/v1/projects/:projectId`

## Test Plan

### Automated Tests
```bash
cd packages/frontend
npm run test
```

**Expected**: All 168 tests pass ✅

### Manual Verification
1. Verify GET requests don't send Content-Type header
2. Verify POST requests with body DO send Content-Type header
3. Verify retry operations work in UI

## Checklist

- [x] Tests updated to match new behavior
- [x] New test added for POST with body
- [x] All tests passing (168/168)
- [x] No regression in coverage
- [x] Commit follows conventional commits format
- [x] Clear documentation of changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)