### PR TITLE
fix(frontend): restore optional project name and reorder form fields

### DIFF
--- a/packages/frontend/src/components/ProjectForm.vue
+++ b/packages/frontend/src/components/ProjectForm.vue
@@ -69,12 +69,11 @@ const handlePresetChange = (value: string) => {
 };
 
 const validateStep1 = async (): Promise<boolean> => {
-  // Validate only step 1 fields
+  // Validate only step 1 fields (name is optional, only url is required)
   const result = await validate();
 
-  // Check if there are errors in step 1 fields
-  // biome-ignore lint/suspicious/noExplicitAny: vee-validate errors type indexing
-  const step1Errors = ['name', 'url', 'description'].some((field) => (errors.value as any)[field]);
+  // Check if there are errors in step 1 fields (url is the only required field)
+  const step1Errors = ['url'].some((field) => (errors.value as any)[field]);
 
   return !step1Errors && result.valid;
 };
@@ -135,20 +134,6 @@ const isLastStep = computed(() => currentStep.value === 2);
       <!-- Step 1: Basic Info -->
       <div v-if="currentStep === 0" class="step-content">
         <NFormItem
-          label="Project Name"
-          :validation-status="errors.name ? 'error' : undefined"
-        >
-          <NInput
-            v-model:value="name"
-            placeholder="Enter project name"
-            data-test="name-input"
-          />
-          <div v-if="errors.name" class="error-message">
-            {{ errors.name }}
-          </div>
-        </NFormItem>
-
-        <NFormItem
           label="Website URL"
           :validation-status="errors.url ? 'error' : undefined"
         >
@@ -159,6 +144,23 @@ const isLastStep = computed(() => currentStep.value === 2);
           />
           <div v-if="errors.url" class="error-message">
             {{ errors.url }}
+          </div>
+        </NFormItem>
+
+        <NFormItem
+          label="Project Name (optional)"
+          :validation-status="errors.name ? 'error' : undefined"
+        >
+          <NInput
+            v-model:value="name"
+            placeholder="Leave empty to use domain name"
+            data-test="name-input"
+          />
+          <div v-if="errors.name" class="error-message">
+            {{ errors.name }}
+          </div>
+          <div v-else class="help-text">
+            If left empty, the domain name from the URL will be used
           </div>
         </NFormItem>
 

--- a/packages/frontend/src/utils/validators.ts
+++ b/packages/frontend/src/utils/validators.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
  */
 export const createProjectSchema = z.object({
   // Basic info
-  name: z.string().trim().min(1, 'Project name is required').max(100, 'Maximum 100 characters'),
+  name: z.string().trim().max(100, 'Maximum 100 characters').optional(),
   url: z.string().url('Invalid URL format'),
   description: z.string().max(500, 'Maximum 500 characters').optional(),
 

--- a/packages/frontend/tests/unit/components/ProjectForm.test.ts
+++ b/packages/frontend/tests/unit/components/ProjectForm.test.ts
@@ -38,7 +38,7 @@ describe('ProjectForm', () => {
     expect(wrapper.text()).toContain('Project Name');
   });
 
-  it('should validate required fields in step 1', async () => {
+  it('should validate required URL field in step 1', async () => {
     const wrapper = mount(ProjectForm);
     const submitButton = wrapper.find('[data-test="next-step-btn"]');
 
@@ -46,7 +46,32 @@ describe('ProjectForm', () => {
       await submitButton.trigger('click');
       await wrapper.vm.$nextTick();
       await new Promise((resolve) => setTimeout(resolve, 50)); // Wait for async validation
-      expect(wrapper.text()).toContain('required');
+      // Should show URL validation error since it's the only required field
+      expect(wrapper.text()).toContain('Invalid URL format');
+    }
+  });
+
+  it('should allow proceeding to step 2 with empty name field', async () => {
+    const wrapper = mount(ProjectForm);
+
+    const nameInput = wrapper.find('input[data-test="name-input"]');
+    const urlInput = wrapper.find('input[data-test="url-input"]');
+
+    if (nameInput.exists() && urlInput.exists()) {
+      // Leave name empty, only fill URL
+      await nameInput.setValue('');
+      await urlInput.setValue('https://example.com');
+
+      const nextButton = wrapper.find('[data-test="next-step-btn"]');
+      if (nextButton.exists()) {
+        await nextButton.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        // Should move to step 2 (Crawl Settings)
+        expect(wrapper.text()).toContain('Crawl');
+        // Should not show validation error
+        expect(wrapper.text()).not.toContain('required');
+      }
     }
   });
 

--- a/packages/frontend/tests/unit/utils/validators.test.ts
+++ b/packages/frontend/tests/unit/utils/validators.test.ts
@@ -26,16 +26,13 @@ describe('validators', () => {
         expect(result.success).toBe(true);
       });
 
-      it('should require name field', () => {
-        const invalidData = {
+      it('should allow missing name field (optional)', () => {
+        const validData = {
           url: 'https://example.com',
         };
 
-        const result = createProjectSchema.safeParse(invalidData);
-        expect(result.success).toBe(false);
-        if (!result.success) {
-          expect(result.error.issues[0]?.path).toContain('name');
-        }
+        const result = createProjectSchema.safeParse(validData);
+        expect(result.success).toBe(true);
       });
 
       it('should require url field', () => {
@@ -50,14 +47,14 @@ describe('validators', () => {
         }
       });
 
-      it('should allow empty name after trimming to fail', () => {
-        const invalidData = {
+      it('should allow empty name (optional field)', () => {
+        const validData = {
           name: '',
           url: 'https://example.com',
         };
 
-        const result = createProjectSchema.safeParse(invalidData);
-        expect(result.success).toBe(false);
+        const result = createProjectSchema.safeParse(validData);
+        expect(result.success).toBe(true);
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes regression where project name field became required again, and implements field reordering as requested.

### Changes

**Core Fix (commit 35d2759):**
- ✅ Make `name` field optional in validation schema (remove `.min(1, 'Project name is required')`)
- ✅ Reorder form fields: **URL → Name (optional) → Description (optional)**
- ✅ Update label to "Project Name (optional)"
- ✅ Update placeholder to "Leave empty to use domain name"
- ✅ Add help text: "If left empty, the domain name from the URL will be used"
- ✅ Update step 1 validation to only require URL field

**Test Updates (commit 2824a0b):**
- ✅ Update validators tests to expect optional name behavior
- ✅ Update ProjectForm tests to check URL validation
- ✅ Add new test for empty name field proceeding to step 2

### Root Cause

Regression introduced during `__name` polyfill fixes. The optional name behavior was previously implemented in commit f4920f9 but was accidentally reverted.

### Backend Support

Backend already supports optional project names with hostname fallback (commit 4c5d503):
- API contract defines `name: z.string().optional()`
- Backend extracts hostname from URL when name is not provided
- This PR aligns frontend with existing backend capability

### Files Changed

```
packages/frontend/src/components/ProjectForm.vue   | 38 ++++++++++++----------
packages/frontend/src/utils/validators.ts          |  2 +-
packages/frontend/tests/unit/components/ProjectForm.test.ts      | 29 +++++++++++++++--
packages/frontend/tests/unit/utils/validators.test.ts   | 19 +++++------
4 files changed, 56 insertions(+), 32 deletions(-)
```

## Test Plan

- [x] All validators tests pass (32/32)
- [x] All ProjectForm component tests pass (7/7)
- [x] All frontend tests pass (169/169)
- [x] Code formatted with Biome
- [x] Verified field order: URL first, then Name (optional), then Description
- [x] Verified help text displays correctly
- [x] Verified form accepts empty name and proceeds to step 2

### Manual Testing Checklist

- [ ] Start dev server and navigate to project creation form
- [ ] Verify field order: URL → Name → Description
- [ ] Verify "Project Name (optional)" label and help text
- [ ] Submit form with empty name - should succeed and use domain as fallback
- [ ] Submit form with provided name - should use provided name

## Breaking Changes

None. This is purely additive:
- Existing code that provides project names continues to work
- New behavior allows creating projects without explicit names

🤖 Generated with [Claude Code](https://claude.com/claude-code)