### PR TITLE
fix(api): correct includePages query parameter boolean coercion

### DIFF
--- a/packages/backend/tests/integration/api/project-details-endpoint.test.ts
+++ b/packages/backend/tests/integration/api/project-details-endpoint.test.ts
@@ -261,9 +261,7 @@ describe('GET /api/v1/projects/:projectId - Project Details', () => {
     expect(body.pages[0].artifacts.htmlUrl).toBe(`/api/v1/artifacts/${page.id}/html`);
   });
 
-  // TODO: Fix includePages query parameter coercion in @ts-rest
-  // The parameter is not being properly coerced from string to boolean
-  it.skip('should respect includePages=false query parameter', async () => {
+  it('should respect includePages=false query parameter', async () => {
     const project = await projectRepo.create({
       name: 'Test Project Include Pages False',
       baseUrl: 'https://example.com',

--- a/packages/shared/src/api-contract.ts
+++ b/packages/shared/src/api-contract.ts
@@ -61,7 +61,10 @@ export const createScanBodySchema = z.object({
 });
 
 export const getProjectQuerySchema = z.object({
-  includePages: z.coerce.boolean().optional(),
+  includePages: z
+    .union([z.boolean(), z.enum(['true', 'false'])])
+    .optional()
+    .transform((val) => (typeof val === 'string' ? val === 'true' : val)),
   pageLimit: z.coerce.number().int().min(1).optional(),
   pageOffset: z.coerce.number().int().min(0).optional(),
 });

--- a/packages/shared/tests/api-contract/query-schemas.test.ts
+++ b/packages/shared/tests/api-contract/query-schemas.test.ts
@@ -53,15 +53,15 @@ describe('Query Schemas', () => {
         }
       });
 
-      it('should coerce non-empty string to boolean true (Zod behavior)', () => {
-        // Note: z.coerce.boolean() uses JavaScript Boolean() coercion
-        // Any non-empty string (including "false") becomes true
+      it('should transform string "false" to boolean false (explicit string parsing)', () => {
+        // Note: Uses z.enum(['true', 'false']).transform() for explicit string parsing
+        // String "false" correctly becomes boolean false
         const validData = { includePages: 'false' };
         const result = getProjectQuerySchema.safeParse(validData);
 
         expect(result.success).toBe(true);
         if (result.success) {
-          expect(result.data.includePages).toBe(true);
+          expect(result.data.includePages).toBe(false);
           expect(typeof result.data.includePages).toBe('boolean');
         }
       });


### PR DESCRIPTION
## Summary
- Fixed `includePages=false` query parameter not being properly coerced from HTTP string to boolean
- Replaced `z.coerce.boolean()` with explicit string parsing using union type and transform
- Re-enabled previously skipped integration test that now passes

## Root Cause
`z.coerce.boolean()` uses JavaScript's `Boolean()` function for coercion, which converts **any non-empty string** (including `"false"`) to `true`:
- `Boolean("false")` → `true` ❌
- `Boolean("true")` → `true` ✅
- `Boolean("")` → `false` ✅

This meant `?includePages=false` was being coerced to `true` instead of `false`.

## Solution
Updated `getProjectQuerySchema` in `packages/shared/src/api-contract.ts`:

```typescript
includePages: z
  .union([z.boolean(), z.enum(['true', 'false'])])
  .optional()
  .transform((val) => (typeof val === 'string' ? val === 'true' : val))
```

This correctly handles:
- HTTP query: `?includePages=false` → boolean `false` ✅
- HTTP query: `?includePages=true` → boolean `true` ✅
- Programmatic: `{ includePages: false }` → boolean `false` ✅
- No parameter → `undefined` → defaults to `true` ✅

## Changes
- **packages/shared/src/api-contract.ts** - Updated query schema with union type and transform
- **packages/shared/tests/api-contract/query-schemas.test.ts** - Updated unit test to verify new behavior
- **packages/backend/tests/integration/api/project-details-endpoint.test.ts** - Re-enabled skipped test, removed TODO comment

## Test Plan
- [x] All shared package tests pass (210/210) ✅
- [x] All backend tests pass (478/478) ✅
- [x] Previously skipped integration test now passes ✅
- [x] Unit test verifies string `"false"` transforms to boolean `false` ✅
- [x] Unit test verifies string `"true"` transforms to boolean `true` ✅

## Manual Verification (Optional)
```bash
# Start backend server
npm run dev:backend

# Test includePages=false (should return empty pages array)
curl "http://localhost:3000/api/v1/projects/{id}?includePages=false"

# Test includePages=true (should return pages array)
curl "http://localhost:3000/api/v1/projects/{id}?includePages=true"

# Test default behavior (should return pages array)
curl "http://localhost:3000/api/v1/projects/{id}"
```

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)