### PR TITLE
docs: add GitHub issue links for frontend phases 3-6

### DIFF
--- a/docs/development/implementation-status.md
+++ b/docs/development/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation Status
 
-**Last Updated**: 2026-01-11
+**Last Updated**: 2026-01-12
 
 ## Current Phase: Phase 5 Complete ✅ | Frontend Phase 2 Complete ✅
 
@@ -271,13 +271,25 @@ See [Drizzle Migration Guide](../guides/drizzle-migration.md) for details.
 - ✅ ProjectDetailView with full project information (10 tests)
 - ✅ 62 new tests (167 total frontend tests passing)
 
-**In Progress (Phase 3)**:
-- ⏳ Run management views (RunList, RunCreate, RunDetail)
+**Pending (Phase 3)** → [#179](https://github.com/gander-tools/diff-voyager/issues/179):
+- ⏳ RunListView → [#185](https://github.com/gander-tools/diff-voyager/issues/185)
+- ⏳ RunCreateView → [#186](https://github.com/gander-tools/diff-voyager/issues/186)
+- ⏳ RunDetailView → [#187](https://github.com/gander-tools/diff-voyager/issues/187)
+- ⏳ RunCard, RunForm, RunStatusBadge, RunProgress, RunStatistics → [#188](https://github.com/gander-tools/diff-voyager/issues/188)-[#192](https://github.com/gander-tools/diff-voyager/issues/192)
 
-**Pending**:
-- ⏳ Diff review interface (Phase 4)
-- ⏳ Rules and settings views (Phase 5)
-- ⏳ Polish, accessibility, and E2E testing (Phase 6)
+**Pending (Phase 4)** → [#180](https://github.com/gander-tools/diff-voyager/issues/180):
+- ⏳ PageDetailView → [#193](https://github.com/gander-tools/diff-voyager/issues/193)
+- ⏳ Page components (PageList, PageStatusBadge, PageFilters) → [#194](https://github.com/gander-tools/diff-voyager/issues/194)-[#196](https://github.com/gander-tools/diff-voyager/issues/196)
+- ⏳ Diff components (DiffSummary, DiffBadge, SeoDiffView, VisualDiffView, PerformanceDiffView, DiffActions) → [#197](https://github.com/gander-tools/diff-voyager/issues/197)-[#202](https://github.com/gander-tools/diff-voyager/issues/202)
+
+**Pending (Phase 5)** → [#183](https://github.com/gander-tools/diff-voyager/issues/183):
+- ⏳ RulesListView, RuleCreateView, SettingsView → [#203](https://github.com/gander-tools/diff-voyager/issues/203)-[#205](https://github.com/gander-tools/diff-voyager/issues/205)
+- ⏳ RuleForm, RuleCard, RuleConditionBuilder → [#206](https://github.com/gander-tools/diff-voyager/issues/206)-[#208](https://github.com/gander-tools/diff-voyager/issues/208)
+
+**Pending (Phase 6)** → [#184](https://github.com/gander-tools/diff-voyager/issues/184):
+- ⏳ Accessibility improvements → [#209](https://github.com/gander-tools/diff-voyager/issues/209)
+- ⏳ E2E tests with Playwright → [#210](https://github.com/gander-tools/diff-voyager/issues/210)
+- ⏳ Performance, error handling, loading states → [#211](https://github.com/gander-tools/diff-voyager/issues/211)-[#213](https://github.com/gander-tools/diff-voyager/issues/213)
 
 **Current UI Capabilities**:
 - Responsive layout with collapsible sidebar
@@ -391,9 +403,10 @@ See [Frontend Implementation Plan](../features/frontend-plan.md) and [Frontend S
 - ❌ Mute rules creation and application
 
 **Frontend UI**:
-- ❌ Run management UI (Phase 3)
-- ❌ Visual diff review (Phase 4)
-- ❌ Rules and settings UI (Phase 5)
+- ❌ Run management UI (Phase 3) → [#179](https://github.com/gander-tools/diff-voyager/issues/179)
+- ❌ Visual diff review (Phase 4) → [#180](https://github.com/gander-tools/diff-voyager/issues/180)
+- ❌ Rules and settings UI (Phase 5) → [#183](https://github.com/gander-tools/diff-voyager/issues/183)
+- ❌ Polish and accessibility (Phase 6) → [#184](https://github.com/gander-tools/diff-voyager/issues/184)
 
 ## Skipped Tests
 
@@ -438,10 +451,11 @@ Full documentation: [Skipped Tests Guide](./skipped-tests.md)
    - 🔵 Search functionality [#166](https://github.com/gander-tools/diff-voyager/issues/166)
 
 ### Long-term (Weeks 9-16)
-5. **Frontend Phase 3-7** - [Milestones #5-7](https://github.com/gander-tools/diff-voyager/milestone/5)
-   - Run management UI (Phase 3)
-   - Diff review interface (Phase 4)
-   - Rules and settings (Phase 5)
+5. **Frontend Phase 3-6** - [Milestones #5-7](https://github.com/gander-tools/diff-voyager/milestone/5)
+   - 🔵 Run management UI (Phase 3) → [#179](https://github.com/gander-tools/diff-voyager/issues/179) (8 sub-issues: #185-#192)
+   - 🔵 Diff review interface (Phase 4) → [#180](https://github.com/gander-tools/diff-voyager/issues/180) (10 sub-issues: #193-#202)
+   - 🔵 Rules and settings (Phase 5) → [#183](https://github.com/gander-tools/diff-voyager/issues/183) (6 sub-issues: #203-#208)
+   - 🔵 Polish and accessibility (Phase 6) → [#184](https://github.com/gander-tools/diff-voyager/issues/184) (5 sub-issues: #209-#213)
 
 See [Roadmap](roadmap.md) for complete development timeline and milestones.
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-**Last Updated**: 2026-01-08
+**Last Updated**: 2026-01-12
 
 ## Current Focus
 
@@ -88,71 +88,80 @@ See GitHub Issues for detailed tracking (all **Feature** type):
 - [#6 - Frontend Phase 4: Diff Review](https://github.com/gander-tools/diff-voyager/milestone/6) - Due Apr 30, 2026
 - [#7 - Frontend MVP Complete](https://github.com/gander-tools/diff-voyager/milestone/7) - Due May 31, 2026
 
-#### 5.1 Project Setup
+#### 5.1 Project Setup ✅
 
-- [ ] Vue 3 + Vite project scaffolding
-- [ ] Pinia store setup
-- [ ] Vue Router configuration
-- [ ] API client service
-- [ ] Component library selection
+- [x] Vue 3 + Vite project scaffolding
+- [x] Pinia store setup
+- [x] Vue Router configuration
+- [x] API client service (@ts-rest)
+- [x] Component library selection (Naive UI)
 
-#### 5.2 Core Views
+#### 5.2 Phase 3: Run Management
 
-- [ ] Project List View
-  - List all projects
-  - Create new project
-  - Delete project
-  - Search and filter
+**Parent Issue**: [#179 - feat(frontend): implement Run Management views](https://github.com/gander-tools/diff-voyager/issues/179)
 
-- [ ] Project Detail View
-  - Project configuration
-  - Runs list with status
-  - Statistics dashboard
-  - Start new comparison run
+**Views**:
+- [ ] 🔵 RunListView → [#185](https://github.com/gander-tools/diff-voyager/issues/185)
+- [ ] 🔵 RunCreateView → [#186](https://github.com/gander-tools/diff-voyager/issues/186)
+- [ ] 🔵 RunDetailView → [#187](https://github.com/gander-tools/diff-voyager/issues/187)
 
-- [ ] Run Detail View
-  - Run metadata and status
-  - Pages list with diff indicators
-  - Filter by change type
-  - Export run results
+**Components**:
+- [ ] 🟡 RunCard → [#188](https://github.com/gander-tools/diff-voyager/issues/188)
+- [ ] 🟡 RunForm → [#189](https://github.com/gander-tools/diff-voyager/issues/189)
+- [ ] 🟡 RunStatusBadge → [#190](https://github.com/gander-tools/diff-voyager/issues/190)
+- [ ] 🟡 RunProgress → [#191](https://github.com/gander-tools/diff-voyager/issues/191)
+- [ ] 🟡 RunStatistics → [#192](https://github.com/gander-tools/diff-voyager/issues/192)
 
-- [ ] Page Diff View
-  - Side-by-side comparison
-  - Visual diff viewer (screenshot overlay)
-  - SEO changes table
-  - Header changes table
-  - Performance metrics chart
+#### 5.3 Phase 4: Diff Review
 
-- [ ] Settings View
-  - Project configuration editor
-  - Mute rules management
-  - Global settings
+**Parent Issue**: [#180 - feat(frontend): implement Diff Review interface](https://github.com/gander-tools/diff-voyager/issues/180)
 
-#### 5.3 Diff Management Features
+**Views**:
+- [ ] 🔵 PageDetailView → [#193](https://github.com/gander-tools/diff-voyager/issues/193)
 
-- [ ] Diff acceptance workflow
-  - Accept individual changes
-  - Accept all changes for page
-  - Undo acceptance
+**Page Components**:
+- [ ] 🟡 PageList → [#194](https://github.com/gander-tools/diff-voyager/issues/194)
+- [ ] 🟡 PageStatusBadge → [#195](https://github.com/gander-tools/diff-voyager/issues/195)
+- [ ] 🟡 PageFilters → [#196](https://github.com/gander-tools/diff-voyager/issues/196)
 
-- [ ] Mute rules creation
-  - Create rule from specific diff
-  - CSS selector picker
-  - XPath generator
-  - Preview affected diffs
+**Diff Components**:
+- [ ] 🟡 DiffSummary → [#197](https://github.com/gander-tools/diff-voyager/issues/197)
+- [ ] 🟡 DiffBadge → [#198](https://github.com/gander-tools/diff-voyager/issues/198)
+- [ ] 🟡 SeoDiffView → [#199](https://github.com/gander-tools/diff-voyager/issues/199)
+- [ ] 🔵 VisualDiffView → [#200](https://github.com/gander-tools/diff-voyager/issues/200)
+- [ ] 🟡 PerformanceDiffView → [#201](https://github.com/gander-tools/diff-voyager/issues/201)
+- [ ] 🟡 DiffActions → [#202](https://github.com/gander-tools/diff-voyager/issues/202)
 
-#### 5.4 UI Polish
+#### 5.4 Phase 5: Rules and Settings
 
-- [ ] Responsive design
-- [ ] Dark mode support
-- [ ] Loading states and skeletons
-- [ ] Error handling and notifications
-- [ ] Keyboard shortcuts
+**Parent Issue**: [#183 - feat(frontend): implement Rules and Settings views](https://github.com/gander-tools/diff-voyager/issues/183)
+
+**Views**:
+- [ ] 🔵 RulesListView → [#203](https://github.com/gander-tools/diff-voyager/issues/203)
+- [ ] 🔵 RuleCreateView → [#204](https://github.com/gander-tools/diff-voyager/issues/204)
+- [ ] 🔵 SettingsView → [#205](https://github.com/gander-tools/diff-voyager/issues/205)
+
+**Components**:
+- [ ] 🟡 RuleForm → [#206](https://github.com/gander-tools/diff-voyager/issues/206)
+- [ ] 🟡 RuleCard → [#207](https://github.com/gander-tools/diff-voyager/issues/207)
+- [ ] 🔵 RuleConditionBuilder → [#208](https://github.com/gander-tools/diff-voyager/issues/208)
+
+#### 5.5 Phase 6: Polish and Accessibility
+
+**Parent Issue**: [#184 - feat(frontend): Polish and Accessibility](https://github.com/gander-tools/diff-voyager/issues/184)
+
+- [ ] 🔵 Accessibility improvements → [#209](https://github.com/gander-tools/diff-voyager/issues/209)
+- [ ] 🔵 E2E tests with Playwright → [#210](https://github.com/gander-tools/diff-voyager/issues/210)
+- [ ] 🟡 Performance optimizations → [#211](https://github.com/gander-tools/diff-voyager/issues/211)
+- [ ] 🟡 Error handling and boundaries → [#212](https://github.com/gander-tools/diff-voyager/issues/212)
+- [ ] 🟡 Loading states and skeleton loaders → [#213](https://github.com/gander-tools/diff-voyager/issues/213)
 
 **Acceptance Criteria**:
 - All core views functional
 - Diff review workflow complete
 - Responsive and accessible UI
+- WCAG 2.1 AA compliance
+- E2E tests for critical flows
 
 See [Frontend Implementation Plan](../features/frontend-plan.md) for detailed specs.
 

--- a/docs/features/frontend-status.md
+++ b/docs/features/frontend-status.md
@@ -1,8 +1,8 @@
 # Frontend Implementation Status
 
-**Last Updated**: 2026-01-09
+**Last Updated**: 2026-01-12
 **Current Phase**: Phase 1 & 2 Complete ✅
-**Next Phase**: Phase 3 (Run Management Views)
+**Next Phase**: Phase 3 (Run Management Views) → [#179](https://github.com/gander-tools/diff-voyager/issues/179)
 
 ---
 
@@ -516,27 +516,38 @@ All requests use shared TypeScript types from `@gander-tools/diff-voyager-shared
 
 ### Run Management
 
-**Not implemented (Phase 3)**:
-- Run list view
-- Run creation form
-- Run detail view with page list
-- Run status polling display
+**Not implemented (Phase 3)** → [#179](https://github.com/gander-tools/diff-voyager/issues/179):
+- Run list view → [#185](https://github.com/gander-tools/diff-voyager/issues/185)
+- Run creation form → [#186](https://github.com/gander-tools/diff-voyager/issues/186)
+- Run detail view with page list → [#187](https://github.com/gander-tools/diff-voyager/issues/187)
+- Run components → [#188](https://github.com/gander-tools/diff-voyager/issues/188)-[#192](https://github.com/gander-tools/diff-voyager/issues/192)
 
 ### Diff Visualization
 
-**Not implemented (Phase 4)**:
-- Visual diff viewer
-- SEO comparison display
-- Performance metrics charts
-- Screenshot comparison tools
-- Diff accept/mute actions
+**Not implemented (Phase 4)** → [#180](https://github.com/gander-tools/diff-voyager/issues/180):
+- Page detail view → [#193](https://github.com/gander-tools/diff-voyager/issues/193)
+- Page components → [#194](https://github.com/gander-tools/diff-voyager/issues/194)-[#196](https://github.com/gander-tools/diff-voyager/issues/196)
+- Visual diff viewer → [#200](https://github.com/gander-tools/diff-voyager/issues/200)
+- SEO comparison display → [#199](https://github.com/gander-tools/diff-voyager/issues/199)
+- Performance metrics charts → [#201](https://github.com/gander-tools/diff-voyager/issues/201)
+- Diff summary and actions → [#197](https://github.com/gander-tools/diff-voyager/issues/197), [#202](https://github.com/gander-tools/diff-voyager/issues/202)
 
 ### Rules & Settings
 
-**Not implemented (Phase 5)**:
-- Rules list and creation
-- Settings management
-- Mute rule application UI
+**Not implemented (Phase 5)** → [#183](https://github.com/gander-tools/diff-voyager/issues/183):
+- Rules list view → [#203](https://github.com/gander-tools/diff-voyager/issues/203)
+- Rule creation form → [#204](https://github.com/gander-tools/diff-voyager/issues/204)
+- Settings management → [#205](https://github.com/gander-tools/diff-voyager/issues/205)
+- Rule components → [#206](https://github.com/gander-tools/diff-voyager/issues/206)-[#208](https://github.com/gander-tools/diff-voyager/issues/208)
+
+### Polish & Accessibility
+
+**Not implemented (Phase 6)** → [#184](https://github.com/gander-tools/diff-voyager/issues/184):
+- Accessibility improvements → [#209](https://github.com/gander-tools/diff-voyager/issues/209)
+- E2E tests → [#210](https://github.com/gander-tools/diff-voyager/issues/210)
+- Performance optimizations → [#211](https://github.com/gander-tools/diff-voyager/issues/211)
+- Error handling → [#212](https://github.com/gander-tools/diff-voyager/issues/212)
+- Loading states → [#213](https://github.com/gander-tools/diff-voyager/issues/213)
 
 ---
 
@@ -656,12 +667,15 @@ All requests use shared TypeScript types from `@gander-tools/diff-voyager-shared
 
 ## Next Steps (Phase 3)
 
+**Parent Issue**: [#179 - feat(frontend): implement Run Management views](https://github.com/gander-tools/diff-voyager/issues/179)
+
 **Immediate Next Priorities**:
 
-1. **Run List View** - Display runs for a project with filtering
-2. **Run Create View** - Form to create comparison runs
-3. **Run Detail View** - Show run status, statistics, and page list
-4. **Run Status Polling** - Real-time status updates during crawling
+1. **Run List View** → [#185](https://github.com/gander-tools/diff-voyager/issues/185) - Display runs for a project with filtering
+2. **Run Create View** → [#186](https://github.com/gander-tools/diff-voyager/issues/186) - Form to create comparison runs
+3. **Run Detail View** → [#187](https://github.com/gander-tools/diff-voyager/issues/187) - Show run status, statistics, and page list
+4. **Run Components** → [#188](https://github.com/gander-tools/diff-voyager/issues/188)-[#192](https://github.com/gander-tools/diff-voyager/issues/192):
+   - RunCard, RunForm, RunStatusBadge, RunProgress, RunStatistics
 
 **Expected Outcomes**:
 - Users can create comparison runs
@@ -669,7 +683,7 @@ All requests use shared TypeScript types from `@gander-tools/diff-voyager-shared
 - Users can see list of pages in a run
 - Full run management workflow working
 
-**Timeline**: Phase 3 planned for Week 5-6
+**Milestone**: [#5 - Frontend Phase 3: Run Management](https://github.com/gander-tools/diff-voyager/milestone/5) - Due Mar 31, 2026
 
 ---
 


### PR DESCRIPTION
Update documentation with links to newly created GitHub issues:

Parent issues:
- #179 (8 sub-issues)
- #180 (10 sub-issues)
- #183 (6 sub-issues)
- #184 (5 sub-issues)

Updated files:
- roadmap.md: Complete frontend section rewrite with issue links
- implementation-status.md: Added pending phases with sub-issue links
- frontend-status.md: Added issue links to "What's NOT Working Yet"

Total: 4 parent issues + 29 sub-issues created via GitHub API