### PR TITLE
ci: integrate github/ai-assessment-comment-labeler for AI-powered issue triage

### DIFF
--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -1,0 +1,45 @@
+# AI Assessment Prompts
+
+This directory contains prompt configurations for the `github/ai-assessment-comment-labeler` action.
+
+## How It Works
+
+1. **Manual Trigger**: A maintainer adds the `needs-assessment` label to an issue
+2. **AI Analysis**: GitHub Actions runs the AI assessment using prompts defined here
+3. **Auto-Labeling**: The action adds appropriate labels based on AI analysis:
+   - `ai:type:bug` - Issue is a bug report
+   - `ai:type:feature` - Issue is a feature request
+   - `ai:type:task` - Issue is a task
+   - `ai:bug-review:ready for triage` - Issue is ready for team review
+4. **Comment**: Optionally posts an AI-generated assessment comment
+
+## Setup Required
+
+### 1. Create the trigger label
+
+Manually create a label in GitHub:
+- Name: `needs-assessment`
+- Description: "Trigger AI assessment of this issue"
+- Color: `#D4C5F9` (purple)
+
+### 2. Usage
+
+When a new issue is created:
+1. Review the issue briefly
+2. Add the `needs-assessment` label
+3. GitHub Actions will automatically analyze and label it
+4. Review AI suggestions and adjust as needed
+
+## Prompt Files
+
+- `issue-triage.prompt.yml` - Main triage prompt for classifying issues
+
+## Configuration
+
+The workflow is configured in `.github/workflows/ai-assessment-comment-labeler.yml`.
+
+## Requirements
+
+- Repository must have `models: read` permission enabled
+- GitHub Models API access (available for public repositories)
+- Manual label creation (see above)

--- a/.github/prompts/issue-triage.prompt.yml
+++ b/.github/prompts/issue-triage.prompt.yml
@@ -1,0 +1,26 @@
+name: Issue Triage
+model:
+  provider: openai
+  name: gpt-4o-mini
+system_prompt: |
+  You are an expert at triaging GitHub issues for Diff Voyager, a local website version comparison tool.
+
+  Analyze the issue and determine:
+  1. Is this a bug report, feature request, or task?
+  2. What severity/priority is it?
+  3. Which component does it affect (backend, frontend, shared, docs)?
+
+  Return a JSON object with:
+  - type: "bug" | "feature" | "task"
+  - severity: "critical" | "high" | "medium" | "low"
+  - component: "backend" | "frontend" | "shared" | "docs" | "ci" | "multiple"
+  - confidence: 0.0-1.0
+  - reasoning: brief explanation
+
+user_prompt: |
+  Title: {{ title }}
+
+  Body:
+  {{ body }}
+
+  Labels: {{ labels }}

--- a/.github/workflows/ai-assessment-comment-labeler.yml
+++ b/.github/workflows/ai-assessment-comment-labeler.yml
@@ -2,17 +2,23 @@ name: AI Issue Assessment
 
 on:
   issues:
-    types: [opened, edited]
+    types: [labeled]  # Trigger when label is added
 
 permissions:
   contents: read
   issues: write
   pull-requests: write
+  models: read  # REQUIRED for GitHub Models API
 
 jobs:
   ai-assessment:
+    # Only run when the 'needs-assessment' label is added
+    if: github.event.label.name == 'needs-assessment'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: AI Assessment and Labeling
         uses: github/ai-assessment-comment-labeler@main
         with:

--- a/.github/workflows/ai-assessment-comment-labeler.yml
+++ b/.github/workflows/ai-assessment-comment-labeler.yml
@@ -1,0 +1,19 @@
+name: AI Issue Assessment
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  ai-assessment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: AI Assessment and Labeling
+        uses: github/ai-assessment-comment-labeler@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📝 Commits

- ci: integrate github/ai-assessment-comment-labeler for AI-powered issue triage

---

Closes #259