### PR TITLE
fix(backend): add missing pino-pretty dependency for logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.11",
-				"@types/node": "^24.10.4",
+				"@types/node": "^22.10.5",
 				"playwright": "^1.57.0",
 				"tsx": "^4.21.0",
 				"typescript": "^5.7.3"
@@ -4837,6 +4837,13 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5133,6 +5140,16 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"date-fns": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"node_modules/dateformat": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/debug": {
@@ -5791,6 +5808,13 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/fast-copy": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
+			"integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-decode-uri-component": {
 			"version": "1.0.1",
@@ -6574,6 +6598,13 @@
 			"integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
 			"license": "MIT"
 		},
+		"node_modules/help-me": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+			"integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/highlight.js": {
 			"version": "11.11.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -7099,6 +7130,16 @@
 			},
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/jquery": {
@@ -8404,6 +8445,54 @@
 			"license": "MIT",
 			"dependencies": {
 				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/pino-pretty": {
+			"version": "13.1.3",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+			"integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"colorette": "^2.0.7",
+				"dateformat": "^4.6.3",
+				"fast-copy": "^4.0.0",
+				"fast-safe-stringify": "^2.1.1",
+				"help-me": "^5.0.0",
+				"joycon": "^3.1.1",
+				"minimist": "^1.2.6",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^3.0.0",
+				"pump": "^3.0.0",
+				"secure-json-parse": "^4.0.0",
+				"sonic-boom": "^4.0.1",
+				"strip-json-comments": "^5.0.2"
+			},
+			"bin": {
+				"pino-pretty": "bin.js"
+			}
+		},
+		"node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+			"integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/pino-pretty/node_modules/strip-json-comments": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+			"integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/pino-std-serializers": {
@@ -10974,6 +11063,7 @@
 				"@types/tmp": "^0.2.6",
 				"@vitest/coverage-v8": "^4.0.0",
 				"drizzle-kit": "^0.31.0",
+				"pino-pretty": "^13.0.0",
 				"supertest": "^7.0.0",
 				"tmp": "^0.2.5",
 				"tsx": "^4.19.2",
@@ -11011,7 +11101,7 @@
 				"@playwright/test": "^1.57.0",
 				"@tsconfig/node24": "^24.0.3",
 				"@types/jsdom": "^27.0.0",
-				"@types/node": "^24.10.7",
+				"@types/node": "^24.10.4",
 				"@vitejs/plugin-vue": "^6.0.3",
 				"@vitest/coverage-v8": "^4.0.0",
 				"@vue/test-utils": "^2.4.6",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -61,6 +61,7 @@
 		"@types/tmp": "^0.2.6",
 		"@vitest/coverage-v8": "^4.0.0",
 		"drizzle-kit": "^0.31.0",
+		"pino-pretty": "^13.0.0",
 		"supertest": "^7.0.0",
 		"tmp": "^0.2.5",
 		"tsx": "^4.19.2",


### PR DESCRIPTION
## Summary

- Added `pino-pretty` as a dev dependency in `packages/backend/package.json`
- Fixes missing dependency error when running backend with logger in pretty mode

## Context

The backend logger was configured to use `pino-pretty` for human-readable log output in development mode, but the dependency was not explicitly declared in the package.json file. This caused runtime errors when the logger tried to use the pretty transport.

## Changes

- Added `pino-pretty@^13.0.0` to backend devDependencies
- Updated package-lock.json with new dependency tree

## Test Plan

- [x] Verify backend starts without dependency errors
- [x] Confirm logger outputs pretty-printed logs in development mode
- [x] Check that production build is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)