### PR TITLE
fix(ci): update Biome version to 2.3.11 in workflow

### DIFF
--- a/.github/workflows/biome-format.yml
+++ b/.github/workflows/biome-format.yml
@@ -46,7 +46,7 @@ jobs:
         id: biome
         run: |
           # Pin Biome to specific version for security and reproducibility
-          npx @biomejs/biome@1.9.4 check --write
+          npx @biomejs/biome@2.3.11 check --write
           echo "format_exit_code=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
 
@@ -108,7 +108,7 @@ jobs:
       - name: Check Biome formatting
         run: |
           # Pin Biome to specific version for security and reproducibility
-          npx @biomejs/biome@1.9.4 ci
+          npx @biomejs/biome@2.3.11 ci
 
       - name: Summary
         if: success()


### PR DESCRIPTION
## Summary

This PR fixes #299 by updating the Biome version in the auto-format workflow from 1.9.4 to 2.3.11 to align with the project's configuration and development dependencies.

## Changes

**Updated `.github/workflows/biome-format.yml`:**
- Line 49: `npx @biomejs/biome@2.3.11 check --write` (was 1.9.4)
- Line 111: `npx @biomejs/biome@2.3.11 ci` (was 1.9.4)

## Context

The project currently uses Biome 2.3.11 in:
- `biome.json` - Schema reference: `https://biomejs.dev/schemas/2.3.11/schema.json`
- `package.json` - Dev dependency: `@biomejs/biome: ^2.3.11`

The workflow was still using the old version 1.9.4, which could lead to:
- ❌ Inconsistent formatting behavior between local development and CI
- ❌ Missing bug fixes and improvements from newer Biome versions
- ❌ Potential schema compatibility issues

## Benefits

After this change:
- ✅ CI/CD uses the same Biome version as local development
- ✅ Consistent formatting results across all environments
- ✅ Access to bug fixes and improvements in v2.3.11
- ✅ No schema compatibility concerns

## Test Plan

- [x] Review changes in workflow file
- [x] Verify version matches biome.json schema (2.3.11)
- [x] Verify version matches package.json dependency (^2.3.11)
- [ ] Workflow will be tested on this PR by CI

## Related

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)