### PR TITLE
fix(backend): configure CORS to allow frontend requests (fixes #306)

### DIFF
--- a/packages/backend/src/api/app.ts
+++ b/packages/backend/src/api/app.ts
@@ -114,9 +114,21 @@ export async function createApp(config: AppConfig): Promise<FastifyInstance> {
  */
 async function registerPlugins(app: FastifyInstance, config: AppConfig) {
   // Register CORS plugin
+  // In development, allow requests from the Vite dev server (localhost:5173)
+  // In production, configure allowed origins via environment variable
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+  const allowedOrigins = isDevelopment
+    ? ['http://localhost:5173', 'http://127.0.0.1:5173']
+    : (process.env.ALLOWED_ORIGINS || '').split(',').filter(Boolean);
+
   await app.register(cors, {
-    origin: true, // Allow all origins in development
+    origin: isDevelopment ? allowedOrigins : allowedOrigins.length > 0 ? allowedOrigins : false,
     credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    exposedHeaders: ['Content-Type'],
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
   });
 
   // Register rate limiting plugin

--- a/packages/backend/src/api/routes-ts-rest.ts
+++ b/packages/backend/src/api/routes-ts-rest.ts
@@ -5,7 +5,12 @@
  * from packages/shared. This is the backend implementation of the contract.
  */
 
-import { apiContract, PageStatus } from '@gander-tools/diff-voyager-shared';
+import {
+  apiContract,
+  PageStatus,
+  type RuleCondition,
+  type RuleScope,
+} from '@gander-tools/diff-voyager-shared';
 import { initServer } from '@ts-rest/fastify';
 import type { FastifyReply } from 'fastify';
 import type { Logger } from 'pino';


### PR DESCRIPTION
## Summary

Fixes #306 - CORS errors on multiple API endpoints blocking frontend functionality.

This PR addresses two issues:
1. **CORS configuration**: The backend CORS was too permissive (`origin: true`) and didn't properly handle preflight OPTIONS requests from the Vite dev server
2. **Missing type imports**: Added `RuleScope` and `RuleCondition` imports that were causing TypeScript compilation errors

## Changes

### CORS Configuration (`packages/backend/src/api/app.ts`)
- Set explicit allowed origins in development: `localhost:5173`, `127.0.0.1:5173`
- Configure production to use `ALLOWED_ORIGINS` environment variable
- Add explicit CORS headers configuration:
  - Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
  - Allowed headers: Content-Type, Authorization
  - Exposed headers: Content-Type
- Set proper preflight handling: `preflightContinue=false`, `optionsSuccessStatus=204`

### Type Imports (`packages/backend/src/api/routes-ts-rest.ts`)
- Added missing `RuleScope` and `RuleCondition` type imports
- Required for rules API handlers type casting

## Test Results

CORS test shows proper headers are now sent:
```
=== CORS Preflight Test ===
Status: 204
Headers:
  Access-Control-Allow-Origin: http://localhost:5173
  Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS
  Access-Control-Allow-Headers: Content-Type, Authorization
  Access-Control-Allow-Credentials: true
```

## Test Plan

- [x] Backend builds successfully with TypeScript
- [x] CORS preflight requests return proper headers
- [x] Actual API requests include CORS headers
- [ ] Frontend can successfully create projects (POST /api/v1/scans)
- [ ] Frontend can load project details (GET /api/v1/projects/:id)
- [ ] Frontend can fetch rules (GET /api/v1/rules)
- [ ] All affected endpoints no longer show CORS errors in browser console

## Related Issues

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)