### PR TITLE
fix(frontend): correct project wizard stepper highlighting

### DIFF
--- a/packages/frontend/src/components/ProjectForm.vue
+++ b/packages/frontend/src/components/ProjectForm.vue
@@ -127,7 +127,7 @@ const isLastStep = computed(() => currentStep.value === 2);
 
 <template>
   <div class="project-form">
-    <NSteps :current="currentStep" class="steps">
+    <NSteps :current="currentStep + 1" class="steps">
       <NStep :title="t('projects.form.stepBasicInfo')" />
       <NStep :title="t('projects.form.stepCrawlSettings')" />
       <NStep :title="t('projects.form.stepRunProfile')" />


### PR DESCRIPTION
## Summary
- Fixed stepper navigation highlighting in project creation wizard
- Converted currentStep from 0-based to 1-based indexing for Naive UI NSteps component
- Step indicators now properly reflect the current form view

## Problem
The stepper component was using 0-based indexing (0, 1, 2) while Naive UI's NSteps component expects 1-based values (1, 2, 3). This caused:
- Step 1 indicator not highlighting when on Basic Info form
- Step indicators highlighting incorrect steps when navigating
- Inconsistent visual feedback throughout the wizard

## Solution
Updated the `:current` binding in NSteps from `currentStep` to `currentStep + 1` to convert from 0-based to 1-based indexing.

## Changes
- `packages/frontend/src/components/ProjectForm.vue:130` - Updated NSteps :current prop

## Test plan
- [x] Code change implemented
- [x] Biome formatter applied
- [x] Manual testing: Navigate to project creation wizard
- [x] Verify step 1 (Basic Info) highlights correctly on initial load
- [x] Verify step 2 (Crawl Settings) highlights when navigating to that step
- [x] Verify step 3 (Run Profile) highlights when navigating to that step
- [x] Verify breadcrumb navigation updates correctly throughout wizard
- [x] Test backward navigation (previous button) - stepper should update correctly

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)