### PR TITLE
perf(backend): add database indexes for query optimization

### DIFF
--- a/packages/backend/src/storage/database.ts
+++ b/packages/backend/src/storage/database.ts
@@ -70,6 +70,16 @@ function runMigrations(db: DatabaseInstance): void {
     applyRulesTableMigration(db);
     db.prepare('INSERT INTO migrations (name) VALUES (?)').run('004-rules-table');
   }
+
+  // Check if database indexes migration was applied
+  const applied005 = db
+    .prepare('SELECT 1 FROM migrations WHERE name = ?')
+    .get('005-database-indexes');
+
+  if (!applied005) {
+    applyDatabaseIndexesMigration(db);
+    db.prepare('INSERT INTO migrations (name) VALUES (?)').run('005-database-indexes');
+  }
 }
 
 /**
@@ -218,6 +228,30 @@ function applyRulesTableMigration(db: DatabaseInstance): void {
     CREATE INDEX idx_rules_project_id ON rules(project_id);
     CREATE INDEX idx_rules_scope ON rules(scope);
     CREATE INDEX idx_rules_active ON rules(active);
+  `);
+}
+
+/**
+ * Apply database indexes migration
+ * Adds indexes for query optimization on frequently queried columns
+ *
+ * Rationale:
+ * - projects.base_url: Used for project lookups and validation
+ * - pages.normalized_url: Speeds up URL lookups across projects
+ * - runs(project_id, is_baseline): Optimizes baseline run queries (common in comparisons)
+ * - snapshots(page_id, run_id): Already exists via UNIQUE constraint (no action needed)
+ */
+function applyDatabaseIndexesMigration(db: DatabaseInstance): void {
+  db.exec(`
+    -- Index on projects.base_url for project lookups
+    CREATE INDEX IF NOT EXISTS idx_projects_base_url ON projects(base_url);
+
+    -- Index on pages.normalized_url for URL lookups
+    CREATE INDEX IF NOT EXISTS idx_pages_normalized_url ON pages(normalized_url);
+
+    -- Composite index on runs(project_id, is_baseline) for baseline queries
+    -- This supplements the existing idx_runs_project_id index
+    CREATE INDEX IF NOT EXISTS idx_runs_project_id_is_baseline ON runs(project_id, is_baseline);
   `);
 }
 

--- a/packages/backend/src/storage/drizzle/schema/pages.ts
+++ b/packages/backend/src/storage/drizzle/schema/pages.ts
@@ -20,6 +20,7 @@ export const pages = sqliteTable(
   },
   (table) => ({
     projectIdIdx: index('idx_pages_project_id').on(table.projectId),
+    normalizedUrlIdx: index('idx_pages_normalized_url').on(table.normalizedUrl),
     projectUrlUnique: unique().on(table.projectId, table.normalizedUrl),
   }),
 );

--- a/packages/backend/src/storage/drizzle/schema/projects.ts
+++ b/packages/backend/src/storage/drizzle/schema/projects.ts
@@ -1,23 +1,29 @@
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 /**
  * Projects table schema
  * Stores project configuration for crawling operations
  */
-export const projects = sqliteTable('projects', {
-  id: text('id').primaryKey(),
-  name: text('name').notNull(),
-  description: text('description'),
-  baseUrl: text('base_url').notNull(),
-  configJson: text('config_json').notNull(),
-  status: text('status').notNull().default('new'),
-  createdAt: text('created_at')
-    .notNull()
-    .$defaultFn(() => new Date().toISOString()),
-  updatedAt: text('updated_at')
-    .notNull()
-    .$defaultFn(() => new Date().toISOString()),
-});
+export const projects = sqliteTable(
+  'projects',
+  {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description'),
+    baseUrl: text('base_url').notNull(),
+    configJson: text('config_json').notNull(),
+    status: text('status').notNull().default('new'),
+    createdAt: text('created_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text('updated_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => ({
+    baseUrlIdx: index('idx_projects_base_url').on(table.baseUrl),
+  }),
+);
 
 // Type inference for SELECT operations
 export type Project = typeof projects.$inferSelect;

--- a/packages/backend/src/storage/drizzle/schema/runs.ts
+++ b/packages/backend/src/storage/drizzle/schema/runs.ts
@@ -24,6 +24,10 @@ export const runs = sqliteTable(
   },
   (table) => ({
     projectIdIdx: index('idx_runs_project_id').on(table.projectId),
+    projectIdIsBaselineIdx: index('idx_runs_project_id_is_baseline').on(
+      table.projectId,
+      table.isBaseline,
+    ),
   }),
 );
 


### PR DESCRIPTION
## Summary

Implements issue #160 by adding database indexes on frequently queried columns to improve query performance.

**Indexes added:**
- Index on `projects.base_url` - Used for project lookups and validation
- Index on `pages.normalized_url` - Speeds up URL lookups across projects
- Composite index on `runs(project_id, is_baseline)` - Optimizes baseline run queries (common in comparisons)

**Note:** The composite index on `snapshots(page_id, run_id)` already exists via the UNIQUE constraint, so no action was needed.

## Changes

- ✅ Updated Drizzle schema files to include new indexes
- ✅ Added migration `005-database-indexes` in `database.ts`
- ✅ Indexes created with `IF NOT EXISTS` for safe reapplication
- ✅ Documented index rationale in migration comments

## Test Plan

- [x] All 479 backend tests pass
- [x] Migration system properly tracks and applies new indexes
- [x] No breaking changes to existing functionality
- [x] Schema files match migration SQL

## Performance Impact

These indexes will improve query performance for:
- Project lookup by base URL
- Page queries across projects by normalized URL
- Baseline run queries (finding baseline runs for a project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)